### PR TITLE
feat: add built-in fuzzy session picker (wyrm -pick)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `wyrm -pick`: an interactive fuzzy picker for running tmux sessions. Type to
+  filter, arrow keys (or Ctrl-N/Ctrl-P) to move, Enter to attach (or
+  `switch-client` when already inside tmux), Ctrl-X to kill the highlighted
+  session, Esc/Ctrl-C to cancel. Running bare `wyrm` in a directory with no
+  config also opens the picker when sessions are already running. The picker is
+  built in — no fzf or other runtime dependency.
+
 ## [0.1.2] - 2026-07-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,11 +63,32 @@ Or build from a clone: `make install` (uses `go install` with a stamped version)
 wyrm                       # use .wyrm.toml (or legacy .tmuxconfig) in the cwd
 wyrm -config path/to/file  # explicit config
 wyrm -kill                 # destroy the session (runs on_project_exit first)
+wyrm -pick                 # fuzzy-pick a running session and attach to it
 wyrm -version
 ```
 
 If neither `.wyrm.toml` nor `.tmuxconfig` is found, wyrm falls back to a
-built-in default: a single unnamed window rooted at the current directory.
+built-in default: a single unnamed window rooted at the current directory —
+unless tmux sessions are already running, in which case `wyrm` opens the
+session picker (below) instead.
+
+## Picking a running session
+
+`wyrm -pick` opens an interactive, fuzzy list of the tmux sessions currently
+running (most-recently-active first) and attaches to the one you choose. It's
+handy from a plain shell, where tmux's own `choose-tree` isn't available
+because you aren't attached to a client yet.
+
+| Key | Action |
+|---|---|
+| type | fuzzy-filter by session name |
+| ↑ / ↓, `Ctrl-P` / `Ctrl-N` | move the selection |
+| `Enter` | attach to the selected session (or `switch-client` if you're already in tmux) |
+| `Ctrl-X` | kill the selected session (no `on_project_exit` hook — it's a plain tmux kill) |
+| `Esc` / `Ctrl-C` | cancel |
+
+The picker is built into the binary — there's no dependency on `fzf` or any
+other external tool, keeping wyrm a single static binary.
 
 If a session with the same name is already running, wyrm **reattaches** to
 it instead of rebuilding it. Otherwise it builds the session fresh, then

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,11 +59,14 @@ Or build from a clone: `make install` (uses `go install` with a stamped version)
 wyrm                       # use .wyrm.toml (or legacy .tmuxconfig) in the cwd
 wyrm -config path/to/file  # explicit config
 wyrm -kill                 # destroy the session (runs on_project_exit first)
+wyrm -pick                 # fuzzy-pick a running session and attach to it
 wyrm -version
 ```
 
 If neither `.wyrm.toml` nor `.tmuxconfig` is found, wyrm falls back to a
-built-in default: a single unnamed window rooted at the current directory.
+built-in default: a single unnamed window rooted at the current directory —
+unless tmux sessions are already running, in which case `wyrm` opens the
+session picker instead.
 
 If a session with the same name is already running, wyrm **reattaches** to
 it instead of rebuilding it. Otherwise it builds the session fresh, then
@@ -71,6 +74,24 @@ attaches.
 
 Run from inside an existing tmux client, wyrm switches the client to the
 session instead of nesting one tmux inside another.
+
+### Picking a running session
+
+`wyrm -pick` opens an interactive, fuzzy list of the running tmux sessions
+(most-recently-active first) and attaches to the one you choose — handy from a
+plain shell, where tmux's own `choose-tree` isn't available because you aren't
+attached to a client yet.
+
+| Key | Action |
+|---|---|
+| type | fuzzy-filter by session name |
+| ↑ / ↓, `Ctrl-P` / `Ctrl-N` | move the selection |
+| `Enter` | attach (or `switch-client` if you're already in tmux) |
+| `Ctrl-X` | kill the selected session (a plain tmux kill, no `on_project_exit`) |
+| `Esc` / `Ctrl-C` | cancel |
+
+The picker is built into the binary — no dependency on `fzf` or any other
+external tool.
 
 See the [configuration reference](configuration.md) for the full `.wyrm.toml`
 format, or the [examples](examples.md) for ready-to-use configs.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/jskoll/wyrm
 
 go 1.21
 
-require github.com/pelletier/go-toml/v2 v2.1.1
+require (
+	github.com/pelletier/go-toml/v2 v2.1.1
+	golang.org/x/term v0.17.0
+)
+
+require golang.org/x/sys v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.17.0 h1:mkTF7LCd6WGJNL3K1Ad7kwxNfYAW6a8a8QqtMblp/4U=
+golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/picker/integration_test.go
+++ b/internal/picker/integration_test.go
@@ -1,0 +1,67 @@
+package picker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/jskoll/wyrm/internal/tmux"
+)
+
+// TestListAndKillIntegration drives a real tmux server on an isolated socket:
+// creates two sessions, verifies ListSessions reports them (most-recently
+// active first), then kills one through KillSession and confirms it's gone.
+// Skipped with -short or without tmux. The interactive Run loop needs a real
+// TTY and is exercised manually, not here.
+func TestListAndKillIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	r := tmux.Exec{SocketName: fmt.Sprintf("wyrm-pick-it-%d", os.Getpid())}
+	t.Cleanup(func() { r.Run("kill-server") }) //nolint:errcheck
+
+	// No server running yet: ListSessions must report empty, not error.
+	if got, err := ListSessions(r); err != nil || len(got) != 0 {
+		t.Fatalf("ListSessions before any server: got %v, err %v; want empty, nil", got, err)
+	}
+
+	for _, name := range []string{"alpha", "beta"} {
+		if out, err := r.Run("new-session", "-d", "-s", name); err != nil {
+			t.Fatalf("new-session %q: %v (%s)", name, err, out)
+		}
+	}
+
+	got, err := ListSessions(r)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d sessions, want 2: %v", len(got), names(got))
+	}
+	seen := map[string]Session{}
+	for _, s := range got {
+		seen[s.Name] = s
+	}
+	if _, ok := seen["alpha"]; !ok {
+		t.Errorf("alpha missing from %v", names(got))
+	}
+	if s, ok := seen["beta"]; !ok || s.Windows != 1 {
+		t.Errorf("beta wrong: %+v", s)
+	}
+
+	if err := KillSession(r, "alpha"); err != nil {
+		t.Fatalf("KillSession: %v", err)
+	}
+	after, err := ListSessions(r)
+	if err != nil {
+		t.Fatalf("ListSessions after kill: %v", err)
+	}
+	if len(after) != 1 || after[0].Name != "beta" {
+		t.Fatalf("after kill got %v, want just beta", names(after))
+	}
+}

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -1,0 +1,480 @@
+// Package picker is an interactive, dependency-free chooser for running tmux
+// sessions. It delivers the fzf experience — type-to-filter fuzzy matching,
+// arrow-key navigation — compiled into the binary, so wyrm keeps its "one
+// static binary, nothing at runtime but tmux" promise.
+//
+// The pure pieces (listing, parsing, fuzzy matching, the list model) are kept
+// separate from the raw-terminal loop so they can be unit-tested through the
+// tmux.Runner mock, the same way tmux.Attach stays out of Runner because it
+// needs the process's stdio.
+package picker
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jskoll/wyrm/internal/tmux"
+	"golang.org/x/term"
+)
+
+// Session is a running tmux session shown in the picker.
+type Session struct {
+	Name     string
+	Windows  int
+	Attached bool
+	Activity time.Time
+}
+
+// listFormat mirrors the pipe-separated fields parseSession expects. tmux
+// rewrites control characters (including tabs) in -F output to "_", so a
+// printable delimiter is required. The session name — the only field that may
+// contain the delimiter — is emitted last so a fixed-count SplitN keeps it
+// whole even when it holds a "|".
+const listFormat = "#{session_windows}|#{?session_attached,1,0}|#{session_activity}|#{session_name}"
+
+// ListSessions returns the running tmux sessions, most-recently-active first.
+// When no tmux server is running it returns an empty slice and no error, so
+// callers can treat "nothing to pick" as an ordinary outcome.
+func ListSessions(r tmux.Runner) ([]Session, error) {
+	out, err := r.Run("list-sessions", "-F", listFormat)
+	if err != nil {
+		// With no server up, tmux fails rather than printing an empty list.
+		// The wording varies: "no server running on <socket>" for the default
+		// server, "error connecting to <socket> (No such file or directory)"
+		// for an -L socket that was never created. Treat both as "nothing to
+		// pick" rather than an error.
+		msg := strings.ToLower(out)
+		if strings.Contains(msg, "no server running") || strings.Contains(msg, "error connecting") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing sessions: %v (%s)", err, out)
+	}
+	var sessions []Session
+	for _, line := range strings.Split(out, "\n") {
+		if s, ok := parseSession(strings.TrimRight(line, "\r")); ok {
+			sessions = append(sessions, s)
+		}
+	}
+	sortSessions(sessions)
+	return sessions, nil
+}
+
+func parseSession(line string) (Session, bool) {
+	if strings.TrimSpace(line) == "" {
+		return Session{}, false
+	}
+	// SplitN with n=4 so a "|" in the name (the last field) is preserved.
+	f := strings.SplitN(line, "|", 4)
+	if len(f) < 4 {
+		return Session{}, false
+	}
+	windows, _ := strconv.Atoi(f[0])
+	epoch, _ := strconv.ParseInt(f[2], 10, 64)
+	return Session{
+		Name:     f[3],
+		Windows:  windows,
+		Attached: f[1] == "1",
+		Activity: time.Unix(epoch, 0),
+	}, true
+}
+
+// sortSessions orders by most recent activity, then name for a stable tie-break.
+func sortSessions(s []Session) {
+	sort.SliceStable(s, func(i, j int) bool {
+		if !s[i].Activity.Equal(s[j].Activity) {
+			return s[i].Activity.After(s[j].Activity)
+		}
+		return s[i].Name < s[j].Name
+	})
+}
+
+// KillSession destroys a session by exact name. Unlike session.Kill it runs no
+// lifecycle hooks: the picker operates on arbitrary running sessions whose
+// config we don't have, so this is a plain tmux kill. The "=" forces an exact
+// match rather than tmux's default prefix match.
+func KillSession(r tmux.Runner, name string) error {
+	if out, err := r.Run("kill-session", "-t", "="+name); err != nil {
+		return fmt.Errorf("killing session %q: %v (%s)", name, err, out)
+	}
+	return nil
+}
+
+// fuzzyMatch reports whether query is a subsequence of target (case-insensitive)
+// along with a score; higher is better. Contiguous runs and matches at a word
+// boundary score higher, so "dev" ranks "dev-api" above "d-e-v". An empty query
+// matches everything with score 0, preserving the caller's input order.
+func fuzzyMatch(query, target string) (int, bool) {
+	if query == "" {
+		return 0, true
+	}
+	q := strings.ToLower(query)
+	t := strings.ToLower(target)
+
+	score, streak, qi, prevTi := 0, 0, 0, -2
+	for ti := 0; ti < len(t) && qi < len(q); ti++ {
+		if t[ti] != q[qi] {
+			continue
+		}
+		score++ // base hit
+		if ti == prevTi+1 {
+			streak++
+			score += 3 + streak // consecutive matches dominate
+		} else {
+			streak = 0
+			if ti == 0 || isBoundary(t[ti-1]) {
+				score += 2 // start-of-word bonus
+			}
+		}
+		prevTi = ti
+		qi++
+	}
+	if qi != len(q) {
+		return 0, false
+	}
+	return score, true
+}
+
+func isBoundary(b byte) bool {
+	switch b {
+	case '-', '_', ' ', '.', '/', ':', '@':
+		return true
+	}
+	return false
+}
+
+// model holds the picker's filtering state. It is pure and unit-tested; the
+// interactive loop drives it in response to key presses.
+type model struct {
+	all      []Session // full session list, activity-ordered
+	query    string
+	filtered []Session // subset matching query, best score first
+	cursor   int
+}
+
+func newModel(sessions []Session) *model {
+	m := &model{all: sessions}
+	m.filter()
+	return m
+}
+
+func (m *model) filter() {
+	type scored struct {
+		s     Session
+		score int
+		order int
+	}
+	var matches []scored
+	for i, s := range m.all {
+		if score, ok := fuzzyMatch(m.query, s.Name); ok {
+			matches = append(matches, scored{s, score, i})
+		}
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].score != matches[j].score {
+			return matches[i].score > matches[j].score
+		}
+		return matches[i].order < matches[j].order // keep activity order on ties
+	})
+	m.filtered = m.filtered[:0]
+	for _, mt := range matches {
+		m.filtered = append(m.filtered, mt.s)
+	}
+	m.clampCursor()
+}
+
+func (m *model) clampCursor() {
+	if m.cursor >= len(m.filtered) {
+		m.cursor = len(m.filtered) - 1
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+}
+
+func (m *model) moveUp() {
+	if m.cursor > 0 {
+		m.cursor--
+	}
+}
+
+func (m *model) moveDown() {
+	if m.cursor < len(m.filtered)-1 {
+		m.cursor++
+	}
+}
+
+func (m *model) appendRune(ch rune) {
+	m.query += string(ch)
+	m.filter()
+}
+
+func (m *model) backspace() {
+	if m.query == "" {
+		return
+	}
+	r := []rune(m.query)
+	m.query = string(r[:len(r)-1])
+	m.filter()
+}
+
+func (m *model) selected() (Session, bool) {
+	if m.cursor < 0 || m.cursor >= len(m.filtered) {
+		return Session{}, false
+	}
+	return m.filtered[m.cursor], true
+}
+
+// Run shows the interactive picker and returns the chosen session name, or ""
+// if the user aborted or there are no sessions to pick.
+func Run(r tmux.Runner) (string, error) {
+	sessions, err := ListSessions(r)
+	if err != nil {
+		return "", err
+	}
+	if len(sessions) == 0 {
+		fmt.Fprintln(os.Stderr, "wyrm: no running tmux sessions")
+		return "", nil
+	}
+
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return "", fmt.Errorf("opening /dev/tty: %w", err)
+	}
+	defer func() { _ = tty.Close() }()
+
+	fd := int(tty.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return "", fmt.Errorf("entering raw mode: %w", err)
+	}
+	defer func() { _ = term.Restore(fd, oldState) }()
+
+	rn := &renderer{w: tty}
+	rn.hideCursor()
+	defer rn.clear()
+
+	m := newModel(sessions)
+	br := bufio.NewReader(tty)
+
+	for {
+		_, height, sizeErr := term.GetSize(fd)
+		if sizeErr != nil || height < 3 {
+			height = len(m.filtered) + 2
+		}
+		rn.draw(m, height-2)
+
+		key, ch, err := readKey(br)
+		if err != nil {
+			return "", err
+		}
+		switch key {
+		case keyEnter:
+			if s, ok := m.selected(); ok {
+				return s.Name, nil
+			}
+		case keyAbort:
+			return "", nil
+		case keyUp:
+			m.moveUp()
+		case keyDown:
+			m.moveDown()
+		case keyKill:
+			s, ok := m.selected()
+			if !ok {
+				break
+			}
+			_ = KillSession(r, s.Name) // ignore: it may already be gone
+			remaining, listErr := ListSessions(r)
+			if listErr != nil || len(remaining) == 0 {
+				return "", listErr
+			}
+			q := m.query
+			m = newModel(remaining)
+			m.query = q
+			m.filter()
+		case keyBackspace:
+			m.backspace()
+		case keyRune:
+			m.appendRune(ch)
+		}
+	}
+}
+
+// key classifies a decoded key press.
+type key int
+
+const (
+	keyNone key = iota
+	keyRune
+	keyEnter
+	keyAbort
+	keyUp
+	keyDown
+	keyBackspace
+	keyKill
+)
+
+// readKey decodes one key press, resolving the common escape sequences for
+// arrow and delete keys. A lone Escape (no bytes queued behind it) aborts.
+func readKey(br *bufio.Reader) (key, rune, error) {
+	b, err := br.ReadByte()
+	if err != nil {
+		return keyNone, 0, err
+	}
+	switch b {
+	case '\r', '\n':
+		return keyEnter, 0, nil
+	case 3: // Ctrl-C
+		return keyAbort, 0, nil
+	case 16: // Ctrl-P
+		return keyUp, 0, nil
+	case 14: // Ctrl-N
+		return keyDown, 0, nil
+	case 24: // Ctrl-X
+		return keyKill, 0, nil
+	case 8, 127: // Backspace / Ctrl-H
+		return keyBackspace, 0, nil
+	case 27: // Escape or an escape sequence
+		if br.Buffered() == 0 {
+			return keyAbort, 0, nil
+		}
+		b2, _ := br.ReadByte()
+		if b2 != '[' && b2 != 'O' {
+			return keyNone, 0, nil
+		}
+		b3, _ := br.ReadByte()
+		switch b3 {
+		case 'A':
+			return keyUp, 0, nil
+		case 'B':
+			return keyDown, 0, nil
+		case '3': // Delete: ESC [ 3 ~
+			_, _ = br.ReadByte() // consume the trailing '~'
+			return keyKill, 0, nil
+		}
+		return keyNone, 0, nil
+	}
+	if b >= 0x80 { // start of a multi-byte UTF-8 rune
+		_ = br.UnreadByte()
+		ch, _, err := br.ReadRune()
+		if err != nil {
+			return keyNone, 0, err
+		}
+		return keyRune, ch, nil
+	}
+	if b >= 0x20 && b < 0x7f {
+		return keyRune, rune(b), nil
+	}
+	return keyNone, 0, nil
+}
+
+// ANSI control sequences used by the renderer.
+const (
+	esc       = "\x1b"
+	clearDown = esc + "[J"
+	clearLine = esc + "[2K"
+	reverse   = esc + "[7m"
+	dim       = esc + "[2m"
+	bold      = esc + "[1m"
+	reset     = esc + "[0m"
+	hideCur   = esc + "[?25l"
+	showCur   = esc + "[?25h"
+)
+
+// renderer redraws the picker in place, tracking how many lines it last drew so
+// the next frame can move the cursor back up and overwrite them instead of
+// scrolling the terminal.
+type renderer struct {
+	w         io.Writer
+	prevLines int
+}
+
+func (rn *renderer) hideCursor() { _, _ = io.WriteString(rn.w, hideCur) }
+
+func (rn *renderer) draw(m *model, maxRows int) {
+	if maxRows < 1 {
+		maxRows = 1
+	}
+	var b strings.Builder
+	if rn.prevLines > 0 {
+		fmt.Fprintf(&b, "%s[%dA", esc, rn.prevLines) // move cursor to top of frame
+	}
+	b.WriteString(clearDown)
+
+	lines := 0
+	writeLine := func(s string) {
+		b.WriteString(clearLine)
+		b.WriteString(s)
+		b.WriteString("\r\n")
+		lines++
+	}
+
+	writeLine(fmt.Sprintf("%s> %s%s", bold, reset, m.query))
+
+	start, end := viewport(m.cursor, len(m.filtered), maxRows)
+	for i := start; i < end; i++ {
+		row := formatRow(m.filtered[i])
+		if i == m.cursor {
+			writeLine(reverse + "> " + row + reset)
+		} else {
+			writeLine("  " + row)
+		}
+	}
+	if len(m.filtered) == 0 {
+		writeLine(dim + "  (no matching sessions)" + reset)
+	}
+
+	writeLine(fmt.Sprintf("%s  %d/%d · up/down move · enter attach · ctrl-x kill · esc quit%s",
+		dim, len(m.filtered), len(m.all), reset))
+
+	rn.prevLines = lines
+	_, _ = io.WriteString(rn.w, b.String())
+}
+
+// clear erases the picker UI and restores the cursor, leaving the terminal
+// clean before wyrm attaches to (or switches to) the chosen session.
+func (rn *renderer) clear() {
+	var b strings.Builder
+	if rn.prevLines > 0 {
+		fmt.Fprintf(&b, "%s[%dA", esc, rn.prevLines)
+	}
+	b.WriteString(clearDown)
+	b.WriteString(showCur)
+	_, _ = io.WriteString(rn.w, b.String())
+	rn.prevLines = 0
+}
+
+// viewport returns the [start,end) slice of rows to show so the cursor stays
+// visible within maxRows.
+func viewport(cursor, n, maxRows int) (int, int) {
+	if n <= maxRows {
+		return 0, n
+	}
+	start := 0
+	if cursor >= maxRows {
+		start = cursor - maxRows + 1
+	}
+	end := start + maxRows
+	if end > n {
+		end = n
+	}
+	return start, end
+}
+
+func formatRow(s Session) string {
+	unit := "windows"
+	if s.Windows == 1 {
+		unit = "window"
+	}
+	att := ""
+	if s.Attached {
+		att = "  (attached)"
+	}
+	return fmt.Sprintf("%-24s %d %s%s", s.Name, s.Windows, unit, att)
+}

--- a/internal/picker/picker_test.go
+++ b/internal/picker/picker_test.go
@@ -1,0 +1,211 @@
+package picker
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// stubRunner returns canned output/err for the first arg it's given and records
+// the calls it received.
+type stubRunner struct {
+	out   string
+	err   error
+	calls [][]string
+}
+
+func (s *stubRunner) Run(args ...string) (string, error) {
+	s.calls = append(s.calls, args)
+	return s.out, s.err
+}
+
+func TestListSessionsParses(t *testing.T) {
+	// Fields are windows|attached|activity|name; beta is the most recently
+	// active, so it must sort first. "weird|name" exercises a name containing
+	// the delimiter (it's the last field, so SplitN keeps it whole).
+	r := &stubRunner{out: strings.Join([]string{
+		"3|1|1000|alpha",
+		"1|0|2000|beta",
+		"1|0|500|weird|name",
+	}, "\n")}
+
+	got, err := ListSessions(r)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d sessions, want 3", len(got))
+	}
+	// Ordered by activity descending: beta(2000), alpha(1000), weird|name(500).
+	if got[0].Name != "beta" || got[1].Name != "alpha" || got[2].Name != "weird|name" {
+		t.Fatalf("wrong order: %q, %q, %q", got[0].Name, got[1].Name, got[2].Name)
+	}
+	if got[1].Windows != 3 || !got[1].Attached {
+		t.Errorf("alpha parsed wrong: %+v", got[1])
+	}
+	if got[0].Attached {
+		t.Errorf("beta should be unattached: %+v", got[0])
+	}
+	// Verify the format string is actually passed to tmux.
+	if len(r.calls) != 1 || r.calls[0][0] != "list-sessions" {
+		t.Fatalf("unexpected tmux call: %v", r.calls)
+	}
+}
+
+func TestListSessionsNoServer(t *testing.T) {
+	r := &stubRunner{out: "no server running on /tmp/tmux-1000/default", err: errors.New("exit status 1")}
+	got, err := ListSessions(r)
+	if err != nil {
+		t.Fatalf("no-server should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want empty, got %v", got)
+	}
+}
+
+func TestListSessionsRealError(t *testing.T) {
+	r := &stubRunner{out: "something else broke", err: errors.New("exit status 1")}
+	if _, err := ListSessions(r); err == nil {
+		t.Fatal("expected error for non-'no server' failure")
+	}
+}
+
+func TestKillSessionExactMatch(t *testing.T) {
+	r := &stubRunner{}
+	if err := KillSession(r, "alpha"); err != nil {
+		t.Fatalf("KillSession: %v", err)
+	}
+	want := []string{"kill-session", "-t", "=alpha"}
+	if len(r.calls) != 1 || !reflect.DeepEqual(r.calls[0], want) {
+		t.Fatalf("got %v, want %v", r.calls, want)
+	}
+}
+
+func TestFuzzyMatch(t *testing.T) {
+	tests := []struct {
+		query, target string
+		want          bool
+	}{
+		{"", "anything", true},
+		{"dev", "dev-api", true},
+		{"dev", "d-e-v", true},
+		{"api", "dev-api", true},
+		{"xyz", "dev-api", false},
+		{"DEV", "dev-api", true}, // case-insensitive
+		{"deva", "dev", false},   // query longer than any subsequence
+	}
+	for _, tt := range tests {
+		_, ok := fuzzyMatch(tt.query, tt.target)
+		if ok != tt.want {
+			t.Errorf("fuzzyMatch(%q, %q) ok=%v, want %v", tt.query, tt.target, ok, tt.want)
+		}
+	}
+}
+
+func TestFuzzyMatchRanksContiguousAndBoundary(t *testing.T) {
+	contig, _ := fuzzyMatch("dev", "dev-api")
+	scattered, _ := fuzzyMatch("dev", "d-e-v")
+	if contig <= scattered {
+		t.Errorf("contiguous %d should outscore scattered %d", contig, scattered)
+	}
+	boundary, _ := fuzzyMatch("api", "dev-api")  // matches at word start
+	midword, _ := fuzzyMatch("api", "devapisrv") // matches mid-word
+	if boundary <= midword {
+		t.Errorf("boundary %d should outscore mid-word %d", boundary, midword)
+	}
+}
+
+func sessions(names ...string) []Session {
+	s := make([]Session, len(names))
+	for i, n := range names {
+		s[i] = Session{Name: n, Windows: 1}
+	}
+	return s
+}
+
+func TestModelFilterOrdersByScore(t *testing.T) {
+	m := newModel(sessions("d-e-v", "dev-api", "prod"))
+	m.appendRune('d')
+	m.appendRune('e')
+	m.appendRune('v')
+	if len(m.filtered) != 2 {
+		t.Fatalf("want 2 matches, got %d: %v", len(m.filtered), names(m.filtered))
+	}
+	// dev-api (contiguous) should rank above d-e-v (scattered).
+	if m.filtered[0].Name != "dev-api" {
+		t.Errorf("best match should be dev-api, got %q", m.filtered[0].Name)
+	}
+}
+
+func TestModelCursorClampsOnFilter(t *testing.T) {
+	m := newModel(sessions("alpha", "beta", "gamma"))
+	m.cursor = 2
+	m.appendRune('l') // only "alpha" contains an 'l', shrinking the list to one
+	if len(m.filtered) != 1 {
+		t.Fatalf("want 1 match for 'l', got %d: %v", len(m.filtered), names(m.filtered))
+	}
+	if m.cursor >= len(m.filtered) {
+		t.Fatalf("cursor %d out of range after filter (len %d)", m.cursor, len(m.filtered))
+	}
+}
+
+func TestModelMovement(t *testing.T) {
+	m := newModel(sessions("a", "b", "c"))
+	m.moveUp() // already at top, no-op
+	if m.cursor != 0 {
+		t.Fatalf("moveUp at top should stay 0, got %d", m.cursor)
+	}
+	m.moveDown()
+	m.moveDown()
+	if m.cursor != 2 {
+		t.Fatalf("want cursor 2, got %d", m.cursor)
+	}
+	m.moveDown() // at bottom, no-op
+	if m.cursor != 2 {
+		t.Fatalf("moveDown at bottom should stay 2, got %d", m.cursor)
+	}
+	s, ok := m.selected()
+	if !ok || s.Name != "c" {
+		t.Fatalf("selected = %v, %v; want c", s.Name, ok)
+	}
+}
+
+func TestModelBackspace(t *testing.T) {
+	m := newModel(sessions("alpha", "beta"))
+	m.appendRune('x') // matches nothing
+	if len(m.filtered) != 0 {
+		t.Fatalf("want 0 matches for 'x', got %d", len(m.filtered))
+	}
+	m.backspace()
+	if len(m.filtered) != 2 {
+		t.Fatalf("backspace should restore all, got %d", len(m.filtered))
+	}
+	m.backspace() // empty query, no-op
+	if m.query != "" {
+		t.Fatalf("query should be empty, got %q", m.query)
+	}
+}
+
+func TestViewport(t *testing.T) {
+	// Fits: whole range.
+	if s, e := viewport(0, 3, 10); s != 0 || e != 3 {
+		t.Errorf("fits: got [%d,%d), want [0,3)", s, e)
+	}
+	// Cursor past the window scrolls it down.
+	if s, e := viewport(5, 10, 3); s != 3 || e != 6 {
+		t.Errorf("scroll: got [%d,%d), want [3,6)", s, e)
+	}
+	// Cursor at end clamps end to n.
+	if s, e := viewport(9, 10, 3); s != 7 || e != 10 {
+		t.Errorf("end: got [%d,%d), want [7,10)", s, e)
+	}
+}
+
+func names(s []Session) []string {
+	out := make([]string, len(s))
+	for i, v := range s {
+		out[i] = v.Name
+	}
+	return out
+}

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 	}
 
 	if *showVersion {
-		fmt.Fprintln(stdout, "wyrm "+version)
+		_, _ = fmt.Fprintln(stdout, "wyrm "+version)
 		return 0
 	}
 
@@ -57,7 +57,7 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 				}
 			}
 			if cfg, err = config.LoadDefault(); err != nil {
-				fmt.Fprintln(stderr, "wyrm: "+err.Error())
+				_, _ = fmt.Fprintln(stderr, "wyrm: "+err.Error())
 				return 1
 			}
 		} else {
@@ -67,7 +67,7 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 	if cfg == nil {
 		var err error
 		if cfg, err = config.Load(path); err != nil {
-			fmt.Fprintln(stderr, "wyrm: "+err.Error())
+			_, _ = fmt.Fprintln(stderr, "wyrm: "+err.Error())
 			return 1
 		}
 	}
@@ -75,22 +75,22 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 	if *kill {
 		name, err := session.Kill(runner, cfg)
 		if err != nil {
-			fmt.Fprintln(stderr, "wyrm: "+err.Error())
+			_, _ = fmt.Fprintln(stderr, "wyrm: "+err.Error())
 			return 1
 		}
-		fmt.Fprintf(stdout, "killed session %s\n", name)
+		_, _ = fmt.Fprintf(stdout, "killed session %s\n", name)
 		return 0
 	}
 
 	name, created, err := session.Create(runner, cfg)
 	if err != nil {
-		fmt.Fprintln(stderr, "wyrm: "+err.Error())
+		_, _ = fmt.Fprintln(stderr, "wyrm: "+err.Error())
 		return 1
 	}
 	if created {
-		fmt.Fprintf(stdout, "created session %s\n", name)
+		_, _ = fmt.Fprintf(stdout, "created session %s\n", name)
 	} else {
-		fmt.Fprintf(stdout, "session %s already running, attaching\n", name)
+		_, _ = fmt.Fprintf(stdout, "session %s already running, attaching\n", name)
 	}
 
 	return attachOrSwitch(runner, stderr, insideTmux, attach, name)
@@ -101,7 +101,7 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 func runPicker(runner tmux.Runner, stderr io.Writer, insideTmux func() bool, attach func(string) error) int {
 	name, err := picker.Run(runner)
 	if err != nil {
-		fmt.Fprintln(stderr, "wyrm: "+err.Error())
+		_, _ = fmt.Fprintln(stderr, "wyrm: "+err.Error())
 		return 1
 	}
 	if name == "" {
@@ -115,14 +115,14 @@ func runPicker(runner tmux.Runner, stderr io.Writer, insideTmux func() bool, att
 func attachOrSwitch(runner tmux.Runner, stderr io.Writer, insideTmux func() bool, attach func(string) error, name string) int {
 	if insideTmux() {
 		if out, err := runner.Run("switch-client", "-t", name); err != nil {
-			fmt.Fprintf(stderr, "wyrm: switching to session: %v (%s)\n", err, out)
+			_, _ = fmt.Fprintf(stderr, "wyrm: switching to session: %v (%s)\n", err, out)
 			return 1
 		}
 		return 0
 	}
 
 	if err := attach(name); err != nil {
-		fmt.Fprintf(stderr, "wyrm: attaching to session: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "wyrm: attaching to session: %v\n", err)
 		return 1
 	}
 	return 0

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/jskoll/wyrm/internal/config"
+	"github.com/jskoll/wyrm/internal/picker"
 	"github.com/jskoll/wyrm/internal/session"
 	"github.com/jskoll/wyrm/internal/tmux"
 )
@@ -27,6 +28,7 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 	fs.SetOutput(stderr)
 	configPath := fs.String("config", "", "path to config file (default: .wyrm.toml, then .tmuxconfig)")
 	kill := fs.Bool("kill", false, "kill the session (runs on_project_exit) instead of creating it")
+	pick := fs.Bool("pick", false, "pick a running tmux session to attach to")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -37,11 +39,23 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 		return 0
 	}
 
+	if *pick {
+		return runPicker(runner, stderr, insideTmux, attach)
+	}
+
 	path := *configPath
 	var cfg *config.Config
 	if path == "" {
 		discovered, err := config.Discover()
 		if err != nil {
+			// No config here: if sessions are already running, offer to pick
+			// one instead of silently building the default session. -kill is
+			// exempt — it targets the default-config session, not the picker.
+			if !*kill {
+				if sessions, lerr := picker.ListSessions(runner); lerr == nil && len(sessions) > 0 {
+					return runPicker(runner, stderr, insideTmux, attach)
+				}
+			}
 			if cfg, err = config.LoadDefault(); err != nil {
 				fmt.Fprintln(stderr, "wyrm: "+err.Error())
 				return 1
@@ -79,7 +93,26 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 		fmt.Fprintf(stdout, "session %s already running, attaching\n", name)
 	}
 
-	// Inside an existing tmux client, attaching would nest — switch instead.
+	return attachOrSwitch(runner, stderr, insideTmux, attach, name)
+}
+
+// runPicker lets the user choose a running session and attaches to it. An
+// empty choice (nothing running, or the user aborted) exits quietly.
+func runPicker(runner tmux.Runner, stderr io.Writer, insideTmux func() bool, attach func(string) error) int {
+	name, err := picker.Run(runner)
+	if err != nil {
+		fmt.Fprintln(stderr, "wyrm: "+err.Error())
+		return 1
+	}
+	if name == "" {
+		return 0
+	}
+	return attachOrSwitch(runner, stderr, insideTmux, attach, name)
+}
+
+// attachOrSwitch hands the terminal to the session, switching the client
+// instead of nesting when wyrm is already running inside tmux.
+func attachOrSwitch(runner tmux.Runner, stderr io.Writer, insideTmux func() bool, attach func(string) error, name string) int {
 	if insideTmux() {
 		if out, err := runner.Run("switch-client", "-t", name); err != nil {
 			fmt.Fprintf(stderr, "wyrm: switching to session: %v (%s)\n", err, out)

--- a/main_test.go
+++ b/main_test.go
@@ -159,7 +159,7 @@ func TestRunAttachError(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	r := &fakeRunner{}
-	attach := func(name string) error { return errors.New("boom") }
+	attach := func(_ string) error { return errors.New("boom") }
 
 	code := run([]string{"-config", path}, &stdout, &stderr, r, func() bool { return false }, attach)
 	if code != 1 {


### PR DESCRIPTION
Add an interactive, dependency-free chooser for running tmux sessions.
Outside tmux there was no way to jump to a running session — tmux's own
choose-tree needs an attached client — so `wyrm -pick` fills that gap.

- New internal/picker package: ListSessions/KillSession over the existing
  tmux.Runner (unit-tested via mock; integration-tested against real tmux),
  a small fuzzy matcher favouring contiguous and word-boundary hits, a pure
  list model, and a raw-mode TTY loop (golang.org/x/term).
- Keys: type to filter, arrows/Ctrl-N/Ctrl-P to move, Enter to attach
  (switch-client when already inside tmux), Ctrl-X to kill the highlighted
  session, Esc/Ctrl-C to cancel.
- main.go: -pick flag, plus an auto-fallback so bare `wyrm` with no config
  opens the picker when sessions are already running (-kill exempt).
- The delimiter for tmux -F is "|" with the session name emitted last:
  tmux rewrites control chars (tabs) to "_", and a name may contain "|".

Rather than shell out to fzf, the picker is compiled in, preserving wyrm's
single-static-binary, no-runtime-deps promise.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H1iorMW5i8zfAH9UBVFfGv