### PR TITLE
perf(tmux): batch commands to spawn fewer processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
       - name: gofmt
         run: test -z "$(gofmt -l .)"
+      # Deleting a package can orphan a dependency, and nothing else notices:
+      # removing internal/picker left golang.org/x/term in go.mod through a
+      # whole release. An untidy go.mod is cosmetic, but it is also the kind of
+      # thing that should never need a human to spot.
+      - name: go mod tidy is clean
+        run: |
+          go mod tidy
+          git diff --exit-code --stat go.mod go.sum
 
   # Dependabot bumps modules on a schedule, but a vulnerability disclosed
   # against a version already pinned here would otherwise go unnoticed until

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-31
+
 ### Changed
 - Building a session issues far fewer tmux processes. Commands are collected
   while the layout is walked and typed in a single `tmux` invocation at the end,
@@ -581,7 +583,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `wyrm -kill` no longer runs `on_project_exit` when the session isn't
   running.
 
-[Unreleased]: https://github.com/jskoll/wyrm/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/jskoll/wyrm/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/jskoll/wyrm/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/jskoll/wyrm/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/jskoll/wyrm/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jskoll/wyrm/compare/v0.4.1...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Building a session issues far fewer tmux processes. Commands are collected
+  while the layout is walked and typed in a single `tmux` invocation at the end,
+  instead of two processes per pane. Measured against a real server on a
+  three-window, six-pane config: **20 processes → 9**.
+- The TUI's agent scan reads every candidate pane in one tmux process rather
+  than one per pane — up to 16, every three seconds, for as long as the TUI is
+  open.
+- Batching is opt-in per Runner (`tmux.BatchRunner`), so the dry-run recorder
+  and every test double keep working unchanged, and `wyrm up -n` still prints
+  one line per tmux command.
+- tmux abandons a batch at its first failure, which would silently cancel every
+  command behind a single dead pane. Commands the batch never reached are
+  replayed individually, preserving the warn-and-continue policy; commands that
+  already succeeded are never re-issued, since replaying a `send-keys` would
+  type its text a second time.
+
+### Fixed
+- `go.mod` still required `golang.org/x/term` after `internal/picker` was
+  removed in 0.6.0. CI now fails on an untidy `go.mod`.
+
 ## [0.6.0] - 2026-07-31
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,15 @@ mistake in how the command was typed (exit 2) and a plain error for a failure
 (exit 1).
 
 Everything that talks to tmux goes through `tmux.Runner`, so it can be driven
-by a recording mock in tests. `main.run` takes its stdio, runner, and attach
-function as parameters for the same reason — the whole CLI is testable without
-a tmux server.
+by a recording mock in tests. A Runner may additionally implement
+`tmux.BatchRunner` to issue several commands in one process; callers reach that
+through `tmux.RunEach` / `tmux.RunOutputsTolerant`, which fall back to one call
+each, so a mock only ever needs `Run`. Note that *embedding* `tmux.Exec` in a
+test double promotes its `RunBatch` — hold it in a named field if the double is
+meant not to batch.
+
+`main.run` takes its stdio, runner, and attach function as parameters for the
+same reason — the whole CLI is testable without a tmux server.
 
 New behavior should come with a unit test against the mocked `tmux.Runner`
 (assert the exact command sequence) and, where it changes real tmux

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,9 +38,11 @@ enabled  = true
 commands = ["claude", "myclaude-wrapper"]
 ```
 
-Agent detection costs one `list-panes` call per refresh plus one `capture-pane`
-for each *matching* pane — panes running an ordinary shell are never captured.
-Set `enabled = false` to stop both.
+Agent detection costs two `tmux` invocations per refresh: one `list-panes` to
+find the candidates, and one batched call that captures all of them together.
+Panes running an ordinary shell are never captured, and the refresh pauses
+entirely while the terminal is unfocused. Set `enabled = false` to stop it
+altogether.
 
 ### Which panes are marked
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,9 +43,15 @@ mistake in how the command was typed (exit 2) and a plain error for a failure
 (exit 1).
 
 Everything that talks to tmux goes through `tmux.Runner`, so it can be driven
-by a recording mock in tests. `main.run` takes its stdio, runner, and attach
-function as parameters for the same reason — the whole CLI is testable without
-a tmux server.
+by a recording mock in tests. A Runner may additionally implement
+`tmux.BatchRunner` to issue several commands in one process; callers reach that
+through `tmux.RunEach` / `tmux.RunOutputsTolerant`, which fall back to one call
+each, so a mock only ever needs `Run`. Note that *embedding* `tmux.Exec` in a
+test double promotes its `RunBatch` — hold it in a named field if the double is
+meant not to batch.
+
+`main.run` takes its stdio, runner, and attach function as parameters for the
+same reason — the whole CLI is testable without a tmux server.
 
 New behavior should come with a unit test against the mocked `tmux.Runner`
 (assert the exact command sequence) and, where it changes real tmux

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/muesli/termenv v0.16.0
 	github.com/pelletier/go-toml/v2 v2.1.1
-	golang.org/x/term v0.17.0
 )
 
 require (
@@ -27,7 +27,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/term v0.17.0 h1:mkTF7LCd6WGJNL3K1Ad7kwxNfYAW6a8a8QqtMblp/4U=
-golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/session/geometry_integration_test.go
+++ b/internal/session/geometry_integration_test.go
@@ -342,3 +342,101 @@ func TestIntegrationRunStartsProcessDirectly(t *testing.T) {
 	}
 	t.Errorf("pane commands = %q, want both panes running sleep directly", out)
 }
+
+// TestIntegrationBatchedBuildSpawnsFewerProcesses measures the thing the
+// batching exists for: how many times wyrm forks tmux to build a session.
+//
+// It counts by wrapping the real Exec rather than trusting a mock, because the
+// whole optimization lives in Exec.RunBatch — a mock that doesn't implement
+// BatchRunner would pass this while proving nothing.
+func TestIntegrationBatchedBuildSpawnsFewerProcesses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	root := t.TempDir()
+	cfg := func(name string) *config.Config {
+		return &config.Config{
+			Session: config.Session{Name: name, Root: root},
+			Windows: []config.Window{
+				{Name: "a", Splits: []config.Split{
+					{Command: "echo one"}, {Type: "h", Command: "echo two"}, {Type: "v", Command: "echo three"},
+				}},
+				{Name: "b", Splits: []config.Split{{Command: "echo four"}, {Type: "h", Command: "echo five"}}},
+				{Name: "c", Splits: []config.Split{{Command: "echo six"}}},
+			},
+		}
+	}
+
+	base := tmux.Exec{SocketName: fmt.Sprintf("wyrm-spawn-it-%d", os.Getpid())}
+	t.Cleanup(func() { _, _ = base.Run("kill-server") })
+
+	batched := &spawnCounter{Exec: base}
+	if _, _, _, err := session.Create(batched, cfg("spawnbatched"), io.Discard, io.Discard); err != nil {
+		t.Fatalf("Create (batched): %v", err)
+	}
+
+	// The same build through a Runner that cannot batch, for the comparison.
+	unbatched := &noBatchCounter{exec: base}
+	if _, _, _, err := session.Create(unbatched, cfg("spawnplain"), io.Discard, io.Discard); err != nil {
+		t.Fatalf("Create (unbatched): %v", err)
+	}
+
+	t.Logf("processes: batched=%d unbatched=%d", batched.n, unbatched.n)
+	if batched.n >= unbatched.n {
+		t.Errorf("batched build spawned %d processes, unbatched %d — batching saved nothing",
+			batched.n, unbatched.n)
+	}
+	// Twelve send-keys collapse into one, so the saving is at least eleven.
+	if saved := unbatched.n - batched.n; saved < 11 {
+		t.Errorf("batching saved only %d processes, want at least 11", saved)
+	}
+
+	// And both sessions must have come out identical.
+	for _, name := range []string{"spawnbatched", "spawnplain"} {
+		out, err := base.Run("list-panes", "-s", "-t", name, "-F", "#{window_name}|#{pane_id}")
+		if err != nil {
+			t.Fatalf("list-panes %s: %v (%s)", name, err, out)
+		}
+		if n := len(strings.Split(strings.TrimSpace(out), "\n")); n != 6 {
+			t.Errorf("session %s has %d panes, want 6", name, n)
+		}
+	}
+}
+
+// spawnCounter counts tmux processes, batching included.
+type spawnCounter struct {
+	tmux.Exec
+	n int
+}
+
+func (s *spawnCounter) Run(args ...string) (string, error) {
+	s.n++
+	return s.Exec.Run(args...)
+}
+
+func (s *spawnCounter) RunBatch(cmds [][]string) ([]string, error) {
+	s.n++
+	return s.Exec.RunBatch(cmds)
+}
+
+// noBatchCounter deliberately does not implement tmux.BatchRunner, so RunEach
+// falls back to one process per command.
+//
+// It holds Exec in a named field rather than embedding it: embedding would
+// *promote* Exec.RunBatch onto this type, making it satisfy BatchRunner after
+// all — and the batch would then run through Exec directly, uncounted. The
+// first version of this test did exactly that and reported the unbatched build
+// as the cheaper one.
+type noBatchCounter struct {
+	exec tmux.Exec
+	n    int
+}
+
+func (s *noBatchCounter) Run(args ...string) (string, error) {
+	s.n++
+	return s.exec.Run(args...)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -102,6 +102,11 @@ func Create(r tmux.Runner, cfg *config.Config, stdout, stderr io.Writer, opts ..
 	}
 	env := envArgs(cfg.Session.Env)
 
+	// Commands are collected while the layout is built and typed in one tmux
+	// process afterwards — see keyBatch. In a three-window, six-pane build that
+	// is twelve send-keys calls collapsed into one.
+	keys := &keyBatch{}
+
 	var id, firstWindowID string
 	for i, w := range cfg.Windows {
 		var out string
@@ -162,8 +167,11 @@ func Create(r tmux.Runner, cfg *config.Config, stdout, stderr io.Writer, opts ..
 			}
 		}
 		_, _ = fmt.Fprintf(stdout, "window %s: %s\n", windowID, w.Name)
-		buildWindow(r, windowID, paneID, w, roots[i], env, stderr)
+		buildWindow(r, windowID, paneID, w, roots[i], env, keys, stderr)
 	}
+
+	// Every pane now exists, so every target is known: type the lot.
+	keys.flush(r, stderr)
 
 	if cfg.Session.StartupWindow != "" {
 		selectStartup(r, id, cfg.Session.StartupWindow, cfg.Session.StartupPane, stderr)
@@ -286,18 +294,18 @@ func paneProcess(w config.Window) []string {
 	return []string{"--", first.Run}
 }
 
-func buildWindow(r tmux.Runner, windowID, initialPane string, w config.Window, root string, env []string, stderr io.Writer) {
+func buildWindow(r tmux.Runner, windowID, initialPane string, w config.Window, root string, env []string, keys *keyBatch, stderr io.Writer) {
 	// done tracks the panes pre_window has already been typed into, so it runs
 	// exactly once per pane across the whole window — see sendPreWindow.
 	done := map[string]bool{}
-	ctx := splitCtx{root: root, env: env, preWindow: w.PreWindow, done: done}
+	ctx := splitCtx{root: root, env: env, preWindow: w.PreWindow, done: done, keys: keys}
 	switch {
 	case len(w.Splits) > 0:
 		applySplits(r, initialPane, w.Splits, ctx, stderr)
 	case len(w.Panes) > 0:
-		applyPanes(r, windowID, initialPane, w, root, env, done, stderr)
+		applyPanes(r, windowID, initialPane, w, root, env, keys, done, stderr)
 	case w.PreWindow != "":
-		sendPreWindow(r, initialPane, w.PreWindow, done, stderr)
+		sendPreWindow(keys, initialPane, w.PreWindow, done)
 	}
 }
 
@@ -309,6 +317,7 @@ type splitCtx struct {
 	env       []string
 	preWindow string
 	done      map[string]bool
+	keys      *keyBatch
 }
 
 // applySplits walks a split tree. Each entry with a type splits the pane of
@@ -352,19 +361,19 @@ func applySplits(r tmux.Runner, basePane string, splits []config.Split, ctx spli
 	// *new* pane, so the loop below never touches basePane — but it is still a
 	// pane of this window, so pre_window still applies to it. At nested levels
 	// basePane is the parent's pane, already in done, so this is a no-op there.
-	sendPreWindow(r, basePane, ctx.preWindow, ctx.done, stderr)
+	sendPreWindow(ctx.keys, basePane, ctx.preWindow, ctx.done)
 
 	for i, s := range splits {
 		pane := panes[i]
 		if pane == "" {
 			continue
 		}
-		sendPreWindow(r, pane, ctx.preWindow, ctx.done, stderr)
+		sendPreWindow(ctx.keys, pane, ctx.preWindow, ctx.done)
 		// A pane created with `run` has no shell to type into: the process is
 		// already what the pane is. splitPane (or paneProcess, for the window's
 		// initial pane) has started it.
 		if s.Run == "" {
-			sendKeys(r, pane, s.Command, stderr)
+			ctx.keys.add(pane, s.Command)
 		} else {
 			// Its own pane has no shell, but it can still parent children.
 			ctx.done[pane] = true
@@ -414,9 +423,9 @@ func splitPane(r tmux.Runner, target string, s config.Split, root string, env []
 
 // applyPanes implements the legacy flat pane list: panes split alternately
 // h/v off the previously created pane, then a layout evens them out.
-func applyPanes(r tmux.Runner, windowID, initialPane string, w config.Window, root string, env []string, done map[string]bool, stderr io.Writer) {
-	sendPreWindow(r, initialPane, w.PreWindow, done, stderr)
-	sendKeys(r, initialPane, w.Panes[0].Command, stderr)
+func applyPanes(r tmux.Runner, windowID, initialPane string, w config.Window, root string, env []string, keys *keyBatch, done map[string]bool, stderr io.Writer) {
+	sendPreWindow(keys, initialPane, w.PreWindow, done)
+	keys.add(initialPane, w.Panes[0].Command)
 
 	current := initialPane
 	for i, p := range w.Panes[1:] {
@@ -439,8 +448,8 @@ func applyPanes(r tmux.Runner, windowID, initialPane string, w config.Window, ro
 			continue
 		}
 		current = out
-		sendPreWindow(r, current, w.PreWindow, done, stderr)
-		sendKeys(r, current, p.Command, stderr)
+		sendPreWindow(keys, current, w.PreWindow, done)
+		keys.add(current, p.Command)
 	}
 
 	layout := w.Layout
@@ -461,18 +470,44 @@ func applyPanes(r tmux.Runner, windowID, initialPane string, w config.Window, ro
 // its parent's pane as its own first entry) and can leave one unvisited (a
 // first entry with a type splits the window's initial pane and lands
 // everything in the new one).
-func sendPreWindow(r tmux.Runner, target, preWindow string, done map[string]bool, stderr io.Writer) {
+func sendPreWindow(keys *keyBatch, target, preWindow string, done map[string]bool) {
 	if preWindow == "" || target == "" || done[target] {
 		return
 	}
 	done[target] = true
-	sendKeys(r, target, preWindow, stderr)
+	keys.add(target, preWindow)
 }
 
-// sendKeys types a command into the target pane. Commands starting with "#"
-// are comments and are skipped.
-func sendKeys(r tmux.Runner, target, command string, stderr io.Writer) {
-	if command == "" || strings.HasPrefix(command, "#") {
+// keySend is one command to type into one pane: the literal text and the Enter
+// that submits it.
+type keySend struct {
+	target, command string
+}
+
+// keyBatch collects every command a build will type, so they can all be issued
+// in one tmux process at the end instead of two processes per pane.
+//
+// Deferring them is safe because a pane's ID is known the moment it is created
+// and never changes — nothing later in the build alters where a command should
+// land. It is also slightly *safer* than typing as we go: the shells have had
+// longer to start by the time anything is sent.
+type keyBatch struct {
+	sends []keySend
+}
+
+// add queues a command. Commands starting with "#" are comments and are
+// skipped, as is the empty string.
+func (k *keyBatch) add(target, command string) {
+	if command == "" || strings.HasPrefix(command, "#") || target == "" {
+		return
+	}
+	k.sends = append(k.sends, keySend{target: target, command: command})
+}
+
+// flush issues everything queued and warns about whatever failed, one warning
+// per command rather than one per tmux call.
+func (k *keyBatch) flush(r tmux.Runner, stderr io.Writer) {
+	if len(k.sends) == 0 {
 		return
 	}
 	// -l types the argument literally and "--" ends the flag list. Without
@@ -480,13 +515,26 @@ func sendKeys(r tmux.Runner, target, command string, stderr io.Writer) {
 	// happens to be one ("up", "space", "tab", "c-c") is sent as that key
 	// instead of typed, and a command starting with "-" is taken for a flag.
 	// Enter is then sent separately, as an actual key.
-	if out, err := r.Run("send-keys", "-t", target, "-l", "--", command); err != nil {
-		warnf(stderr, "failed to run %q in %s: %v (%s)", command, target, err, out)
-		return
+	cmds := make([][]string, 0, len(k.sends)*2)
+	for _, s := range k.sends {
+		cmds = append(cmds,
+			[]string{"send-keys", "-t", s.target, "-l", "--", s.command},
+			[]string{"send-keys", "-t", s.target, "Enter"})
 	}
-	if out, err := r.Run("send-keys", "-t", target, "Enter"); err != nil {
-		warnf(stderr, "failed to run %q in %s: %v (%s)", command, target, err, out)
+
+	errs := tmux.RunEach(r, cmds)
+	for i, s := range k.sends {
+		// Either half failing means the command didn't run as typed; report it
+		// once, naming the command rather than the tmux call.
+		if err := errs[i*2]; err != nil {
+			warnf(stderr, "failed to run %q in %s: %v", s.command, s.target, err)
+			continue
+		}
+		if err := errs[i*2+1]; err != nil {
+			warnf(stderr, "failed to run %q in %s: %v", s.command, s.target, err)
+		}
 	}
+	k.sends = nil
 }
 
 // selectStartup focuses the session's startup window (given by name or index)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
@@ -121,17 +122,29 @@ func TestCreateSplitTree(t *testing.T) {
 		t.Error("created = false, want true")
 	}
 
-	// Note the ordering: both siblings at the top level are created before
-	// the nested child, so the child splits %2 at its full size rather than
-	// after a later sibling has already carved it up. pre_window is typed once
-	// per pane, and every command goes through "send-keys -l --" plus a
-	// separate Enter so a command that looks like a key name is still typed.
+	// Note two orderings here.
+	//
+	// Both siblings at the top level are created before the nested child, so
+	// the child splits %2 at its full size rather than after a later sibling
+	// has already carved it up.
+	//
+	// And every pane is created before anything is typed: commands are
+	// collected during the walk and issued together at the end, which lets a
+	// batching Runner send them in one tmux process (see keyBatch). This mock
+	// doesn't batch, so they appear individually — the commands and their
+	// targets are unchanged either way, only the grouping moved.
+	//
+	// pre_window is typed once per pane, and every command goes through
+	// "send-keys -l --" plus a separate Enter so a command that looks like a
+	// key name is still typed.
 	want := []string{
 		"list-sessions -F #{session_id}|#{session_name}",
 		"new-session -d -P -F #{session_id}|#{session_name}|#{window_id}|#{pane_id} -s proj -n editor -c /tmp/proj",
 		// second entry splits the initial pane %1 -> %2 (breadth first)
 		"split-window -d -t %1 -h -P -F #{pane_id} -c /tmp/proj -l 30%",
-		// first split entry: no type, reuses initial pane %1
+		// child splits its parent %2 -> %3
+		"split-window -d -t %2 -v -P -F #{pane_id} -c /tmp/proj",
+		// now the collected commands, in walk order
 		"send-keys -t %1 -l -- nvm use 18",
 		"send-keys -t %1 Enter",
 		"send-keys -t %1 -l -- nvim",
@@ -140,8 +153,6 @@ func TestCreateSplitTree(t *testing.T) {
 		"send-keys -t %2 Enter",
 		"send-keys -t %2 -l -- npm run dev",
 		"send-keys -t %2 Enter",
-		// child splits its parent %2 -> %3
-		"split-window -d -t %2 -v -P -F #{pane_id} -c /tmp/proj",
 		"send-keys -t %3 -l -- nvm use 18",
 		"send-keys -t %3 Enter",
 		"send-keys -t %3 -l -- npm test",
@@ -677,3 +688,152 @@ func TestCreatePassesEnv(t *testing.T) {
 		}
 	}
 }
+
+// batchingRunner is a fakeRunner that also implements tmux.BatchRunner, so a
+// test can see that the build actually batches rather than quietly falling back
+// to one call per command — which is what every other mock here does.
+type batchingRunner struct {
+	fakeRunner
+	batches [][][]string
+	// direct records only the calls issued one at a time, so a test can tell a
+	// batched command from one that bypassed the batch. RunBatch reuses
+	// fakeRunner.Run to fabricate outputs, which would otherwise make the two
+	// indistinguishable.
+	direct  []string
+	inBatch bool
+}
+
+func (b *batchingRunner) Run(args ...string) (string, error) {
+	if !b.inBatch {
+		b.direct = append(b.direct, strings.Join(args, " "))
+	}
+	return b.fakeRunner.Run(args...)
+}
+
+func (b *batchingRunner) RunBatch(cmds [][]string) ([]string, error) {
+	b.batches = append(b.batches, cmds)
+	b.inBatch = true
+	defer func() { b.inBatch = false }()
+	outs := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		out, err := b.Run(c...)
+		if err != nil {
+			return outs, err
+		}
+		outs = append(outs, out)
+	}
+	return outs, nil
+}
+
+// TestCreateBatchesEveryCommandIntoOneCall is the point of the whole exercise:
+// a six-pane build issued twelve send-keys processes, and now issues one batch.
+func TestCreateBatchesEveryCommandIntoOneCall(t *testing.T) {
+	cfg := &config.Config{
+		Session: config.Session{Name: "proj", Root: "/tmp/proj"},
+		Windows: []config.Window{
+			{Name: "a", Splits: []config.Split{
+				{Command: "one"}, {Type: "h", Command: "two"}, {Type: "v", Command: "three"},
+			}},
+			{Name: "b", Splits: []config.Split{{Command: "four"}, {Type: "h", Command: "five"}}},
+			{Name: "c", Splits: []config.Split{{Command: "six"}}},
+		},
+	}
+
+	r := &batchingRunner{}
+	if _, _, _, err := Create(r, cfg, io.Discard, io.Discard); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if len(r.batches) != 1 {
+		t.Fatalf("issued %d batches, want exactly 1", len(r.batches))
+	}
+	// Six commands, each a literal plus an Enter.
+	if got := len(r.batches[0]); got != 12 {
+		t.Errorf("batch held %d commands, want 12", got)
+	}
+	for _, c := range r.batches[0] {
+		if c[0] != "send-keys" {
+			t.Errorf("batch contained a non-send-keys command %v", c)
+		}
+	}
+	// And nothing was typed outside the batch.
+	for _, c := range r.direct {
+		if strings.HasPrefix(c, "send-keys") {
+			t.Errorf("send-keys issued outside the batch: %q", c)
+		}
+	}
+}
+
+// A pane that dies mid-build must not cancel the commands queued after it, and
+// must not cause an already-typed command to be typed a second time.
+func TestCreateReplaysOnlyAfterAFailedSend(t *testing.T) {
+	cfg := &config.Config{
+		Session: config.Session{Name: "proj", Root: "/tmp/proj"},
+		Windows: []config.Window{{Name: "w", Splits: []config.Split{
+			{Command: "first"}, {Type: "h", Command: "second"}, {Type: "v", Command: "third"},
+		}}},
+	}
+
+	// Fail the send to %2 — the middle pane — however it is issued.
+	r := &partialBatchRunner{failTarget: "%2"}
+	var stderr bytes.Buffer
+	if _, _, _, err := Create(r, cfg, io.Discard, &stderr); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	typed := r.typed()
+	// %1 and %3 still got their commands: one bad pane doesn't cancel the rest.
+	for _, want := range []string{"first", "third"} {
+		if !slices.Contains(typed, want) {
+			t.Errorf("%q was never typed; typed=%v", want, typed)
+		}
+	}
+	// Nothing was typed twice — replaying a send-keys would duplicate input.
+	seen := map[string]int{}
+	for _, c := range typed {
+		seen[c]++
+	}
+	for c, n := range seen {
+		if n > 1 {
+			t.Errorf("%q was typed %d times, want once", c, n)
+		}
+	}
+	if !strings.Contains(stderr.String(), "second") {
+		t.Errorf("stderr = %q, want a warning naming the command that failed", stderr.String())
+	}
+}
+
+// partialBatchRunner batches, but fails any send-keys aimed at failTarget —
+// which stops the batch there, exactly as tmux does.
+type partialBatchRunner struct {
+	fakeRunner
+	failTarget string
+	sent       []string
+}
+
+func (p *partialBatchRunner) send(args []string) (string, error) {
+	if args[0] == "send-keys" && args[2] == p.failTarget {
+		return "can't find pane", errors.New("exit status 1")
+	}
+	// Record only the literal half, which carries the command text.
+	if args[0] == "send-keys" && len(args) > 5 && args[3] == "-l" {
+		p.sent = append(p.sent, args[5])
+	}
+	return p.fakeRunner.Run(args...)
+}
+
+func (p *partialBatchRunner) Run(args ...string) (string, error) { return p.send(args) }
+
+func (p *partialBatchRunner) RunBatch(cmds [][]string) ([]string, error) {
+	outs := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		out, err := p.send(c)
+		if err != nil {
+			return outs, err // tmux abandons the rest of the batch
+		}
+		outs = append(outs, out)
+	}
+	return outs, nil
+}
+
+func (p *partialBatchRunner) typed() []string { return p.sent }

--- a/internal/tmux/batch.go
+++ b/internal/tmux/batch.go
@@ -1,0 +1,195 @@
+package tmux
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// BatchRunner is implemented by a Runner that can issue several tmux commands
+// in one process. It is deliberately separate from Runner: callers reach it
+// through RunEach/RunBatch, which fall back to one call per command, so mocks
+// and the dry-run recorder need not implement it.
+//
+// DryRun in particular must *not* implement it — `wyrm up -n` prints one line
+// per tmux command, and that transcript is the feature.
+type BatchRunner interface {
+	// RunBatch issues cmds in a single tmux process and returns the output of
+	// each command that completed, in order. tmux stops a batch at its first
+	// failure, so a result shorter than cmds says exactly where it stopped:
+	// len(results) commands succeeded, and cmds[len(results)] is the one that
+	// failed.
+	RunBatch(cmds [][]string) ([]string, error)
+}
+
+// batchSep is the argument tmux reads as "end of this command". It is passed as
+// its own argv element, so no shell is involved and no quoting applies.
+const batchSep = ";"
+
+// newBatchMarker returns the token printed after each command in a batch, so
+// the caller can count how many ran. It is randomized per batch because the
+// output being delimited includes user-controlled text — a session or window
+// name could otherwise contain a fixed marker and shift every result by one.
+func newBatchMarker() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Any token is better than none here; a collision only mis-splits
+		// output that a caller is about to discard as failed anyway.
+		return "wyrm-batch-marker"
+	}
+	return "wyrm-batch-" + hex.EncodeToString(b[:])
+}
+
+// RunBatch implements BatchRunner for the real tmux.
+//
+// It captures stdout and stderr separately rather than going through Run, which
+// substitutes stderr for stdout on failure: a partly-completed batch needs both
+// — the output to count what ran, and the diagnostic to say why it stopped.
+func (e Exec) RunBatch(cmds [][]string) ([]string, error) {
+	if len(cmds) == 0 {
+		return nil, nil
+	}
+
+	marker := newBatchMarker()
+	var args []string
+	if e.SocketName != "" {
+		args = append(args, "-L", e.SocketName)
+	}
+	for i, c := range cmds {
+		if i > 0 {
+			args = append(args, batchSep)
+		}
+		args = append(args, c...)
+		// A marker after every command, so a command that prints nothing
+		// (send-keys) is still countable.
+		args = append(args, batchSep, "display-message", "-p", marker)
+	}
+
+	cmd := exec.Command("tmux", args...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	runErr := cmd.Run()
+
+	results := splitOnMarker(stdout.String(), marker)
+	if runErr == nil {
+		return results, nil
+	}
+
+	msg := strings.TrimSpace(stderr.String())
+	if noServerText(msg) {
+		return results, fmt.Errorf("%w: %w", ErrNoServer, runErr)
+	}
+	if msg == "" {
+		return results, runErr
+	}
+	return results, fmt.Errorf("%w (%s)", runErr, msg)
+}
+
+// splitOnMarker cuts batch output into one entry per completed command. Lines
+// before the first marker belong to the first command, and so on; the trailing
+// text after the last marker belongs to a command that never finished and is
+// dropped.
+func splitOnMarker(out, marker string) []string {
+	if out == "" {
+		return nil
+	}
+	var results []string
+	var cur []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimRight(line, "\r") == marker {
+			results = append(results, strings.TrimSpace(strings.Join(cur, "\n")))
+			cur = cur[:0]
+			continue
+		}
+		cur = append(cur, line)
+	}
+	return results
+}
+
+// RunEach issues every command in cmds and returns a slice of errors aligned
+// with it: nil where the command succeeded.
+//
+// It uses one tmux process when the Runner supports batching, and one per
+// command when it doesn't. Because tmux abandons a batch at its first failure,
+// the commands it never reached are replayed individually — otherwise a single
+// broken command would silently cancel every command after it, which is not
+// internal/session's documented "warn and continue" policy.
+//
+// Commands that already succeeded are never re-issued. That matters: replaying
+// a send-keys would type its text into the pane a second time, which is a worse
+// outcome than the failure being recovered from. This relies on a failed tmux
+// command having had no effect, which holds for the commands wyrm batches
+// (send-keys, capture-pane) — they fail by not finding their target.
+func RunEach(r Runner, cmds [][]string) []error {
+	errs := make([]error, len(cmds))
+	if len(cmds) == 0 {
+		return errs
+	}
+
+	start := 0
+	if b, ok := r.(BatchRunner); ok {
+		results, err := b.RunBatch(cmds)
+		if err == nil && len(results) >= len(cmds) {
+			return errs
+		}
+		// len(results) commands ran; the next one is where it stopped.
+		start = min(len(results), len(cmds))
+	}
+
+	for i := start; i < len(cmds); i++ {
+		if out, err := r.Run(cmds[i]...); err != nil {
+			errs[i] = batchCmdErr(err, out)
+		}
+	}
+	return errs
+}
+
+// RunOutputsTolerant issues every command and returns each one's output —
+// empty where it failed — alongside the matching errors, both aligned with
+// cmds.
+//
+// It is RunEach for reads: one tmux process when the Runner batches, with the
+// commands a failure cut short replayed individually so one dead target doesn't
+// discard every result after it. That is the case it exists for — the TUI's
+// agent scan captures a set of panes, any of which may have closed since the
+// list that named them.
+func RunOutputsTolerant(r Runner, cmds [][]string) ([]string, []error) {
+	outs := make([]string, len(cmds))
+	errs := make([]error, len(cmds))
+	if len(cmds) == 0 {
+		return outs, errs
+	}
+
+	start := 0
+	if b, ok := r.(BatchRunner); ok {
+		results, err := b.RunBatch(cmds)
+		copy(outs, results)
+		if err == nil && len(results) >= len(cmds) {
+			return outs, errs
+		}
+		start = min(len(results), len(cmds))
+	}
+
+	for i := start; i < len(cmds); i++ {
+		out, err := r.Run(cmds[i]...)
+		if err != nil {
+			errs[i] = batchCmdErr(err, out)
+			continue
+		}
+		outs[i] = out
+	}
+	return outs, errs
+}
+
+func batchCmdErr(err error, out string) error {
+	if out == "" {
+		return err
+	}
+	if errors.Is(err, ErrNoServer) {
+		return err
+	}
+	return fmt.Errorf("%w (%s)", err, out)
+}

--- a/internal/tmux/batch_test.go
+++ b/internal/tmux/batch_test.go
@@ -1,0 +1,233 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// loopRunner is a Runner with no batching, to exercise the fallback path.
+type loopRunner struct {
+	calls [][]string
+	fail  map[int]bool // index of calls that should fail
+	out   map[int]string
+}
+
+func (l *loopRunner) Run(args ...string) (string, error) {
+	i := len(l.calls)
+	l.calls = append(l.calls, args)
+	if l.fail[i] {
+		return "boom", errors.New("exit status 1")
+	}
+	return l.out[i], nil
+}
+
+func TestRunEachFallsBackWithoutBatching(t *testing.T) {
+	r := &loopRunner{fail: map[int]bool{1: true}}
+	errs := RunEach(r, [][]string{{"a"}, {"b"}, {"c"}})
+	if len(r.calls) != 3 {
+		t.Fatalf("issued %d calls, want one per command: %v", len(r.calls), r.calls)
+	}
+	if errs[0] != nil || errs[2] != nil {
+		t.Errorf("errs = %v, want only the middle one set", errs)
+	}
+	if errs[1] == nil {
+		t.Error("the failing command reported no error")
+	}
+	// The whole point of the policy: a failure does not cancel what follows.
+	if got := strings.Join(r.calls[2], " "); got != "c" {
+		t.Errorf("third call = %q, want it to have run anyway", got)
+	}
+}
+
+func TestRunEachEmpty(t *testing.T) {
+	r := &loopRunner{}
+	if errs := RunEach(r, nil); len(errs) != 0 {
+		t.Errorf("errs = %v, want empty", errs)
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("issued %v for an empty batch", r.calls)
+	}
+}
+
+// batchStub reports that the first n commands succeeded, then failed.
+type batchStub struct {
+	loopRunner
+	completed int
+	batches   int
+}
+
+func (b *batchStub) RunBatch(cmds [][]string) ([]string, error) {
+	b.batches++
+	if b.completed >= len(cmds) {
+		return make([]string, len(cmds)), nil
+	}
+	return make([]string, b.completed), errors.New("exit status 1")
+}
+
+// The happy path is a single process and no per-command calls at all.
+func TestRunEachBatchesWhenSupported(t *testing.T) {
+	b := &batchStub{completed: 3}
+	errs := RunEach(b, [][]string{{"a"}, {"b"}, {"c"}})
+	if b.batches != 1 {
+		t.Errorf("issued %d batches, want 1", b.batches)
+	}
+	if len(b.calls) != 0 {
+		t.Errorf("fell back to individual calls: %v", b.calls)
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("errs[%d] = %v, want nil", i, err)
+		}
+	}
+}
+
+// The replay must resume at the failure, never re-issuing what already ran —
+// re-typing a send-keys would be worse than the failure it recovers from.
+func TestRunEachReplaysOnlyFromTheFailure(t *testing.T) {
+	b := &batchStub{completed: 2} // a, b ran; c failed
+	b.fail = map[int]bool{0: true}
+	errs := RunEach(b, [][]string{{"a"}, {"b"}, {"c"}, {"d"}})
+
+	if b.batches != 1 {
+		t.Errorf("issued %d batches, want 1", b.batches)
+	}
+	var replayed []string
+	for _, c := range b.calls {
+		replayed = append(replayed, strings.Join(c, " "))
+	}
+	want := []string{"c", "d"}
+	if len(replayed) != len(want) {
+		t.Fatalf("replayed %v, want exactly %v — a and b already took effect", replayed, want)
+	}
+	for i := range want {
+		if replayed[i] != want[i] {
+			t.Errorf("replayed[%d] = %q, want %q", i, replayed[i], want[i])
+		}
+	}
+	if errs[0] != nil || errs[1] != nil {
+		t.Errorf("errs = %v, want the batched-and-succeeded commands unmarked", errs)
+	}
+	if errs[2] == nil {
+		t.Error("the failing command reported no error after replay")
+	}
+	if errs[3] != nil {
+		t.Errorf("errs[3] = %v, want nil — it ran fine on replay", errs[3])
+	}
+}
+
+func TestSplitOnMarker(t *testing.T) {
+	const m = "MARK"
+	tests := []struct {
+		name string
+		out  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"no output per command", m + "\n" + m, []string{"", ""}},
+		{"one line each", "a\n" + m + "\nb\n" + m, []string{"a", "b"}},
+		{"multi-line", "a1\na2\n" + m + "\nb1\n" + m, []string{"a1\na2", "b1"}},
+		// Trailing text belongs to a command that never finished: dropped.
+		{"unfinished tail", "a\n" + m + "\npartial", []string{"a"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitOnMarker(tt.out, m)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestIntegrationRunBatch drives a real tmux: the batch has to run in one
+// process, return each command's own output, and — on a mid-batch failure —
+// report exactly how many commands got through.
+func TestIntegrationRunBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	r := Exec{SocketName: fmt.Sprintf("wyrm-batch-it-%d", os.Getpid())}
+	t.Cleanup(func() { _, _ = r.Run("kill-server") })
+	if out, err := r.Run("new-session", "-d", "-s", "b", "-n", "w"); err != nil {
+		t.Fatalf("new-session: %v (%s)", err, out)
+	}
+
+	// Outputs come back per command, in order.
+	results, err := r.RunBatch([][]string{
+		{"display-message", "-p", "one"},
+		{"display-message", "-p", "two"},
+		{"list-windows", "-t", "b", "-F", "w:#{window_name}"},
+	})
+	if err != nil {
+		t.Fatalf("RunBatch: %v", err)
+	}
+	want := []string{"one", "two", "w:w"}
+	if len(results) != len(want) {
+		t.Fatalf("results = %q, want %q", results, want)
+	}
+	for i := range want {
+		if results[i] != want[i] {
+			t.Errorf("results[%d] = %q, want %q", i, results[i], want[i])
+		}
+	}
+
+	// A command producing no output still occupies its slot, so indices stay
+	// aligned with the commands that produced them.
+	results, err = r.RunBatch([][]string{
+		{"send-keys", "-t", "b", "-l", "--", "x"},
+		{"display-message", "-p", "after"},
+	})
+	if err != nil {
+		t.Fatalf("RunBatch with a silent command: %v", err)
+	}
+	if len(results) != 2 || results[0] != "" || results[1] != "after" {
+		t.Errorf("results = %q, want [\"\" \"after\"]", results)
+	}
+
+	// Mid-batch failure: tmux abandons the rest, and the short result says where.
+	results, err = r.RunBatch([][]string{
+		{"display-message", "-p", "ran"},
+		{"kill-pane", "-t", "%999"},
+		{"display-message", "-p", "never"},
+	})
+	if err == nil {
+		t.Fatal("RunBatch with a bad command returned no error")
+	}
+	if len(results) != 1 {
+		t.Errorf("results = %q, want exactly the 1 command that completed", results)
+	}
+	if !strings.Contains(err.Error(), "%999") {
+		t.Errorf("err = %v, want tmux's own diagnostic", err)
+	}
+}
+
+// No server running has to survive batching as the ordinary outcome it is.
+func TestIntegrationRunBatchNoServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	r := Exec{SocketName: fmt.Sprintf("wyrm-batch-none-%d", os.Getpid())}
+	_, err := r.RunBatch([][]string{{"list-sessions"}})
+	if err == nil {
+		t.Fatal("want an error with no server running")
+	}
+	if !errors.Is(err, ErrNoServer) {
+		t.Errorf("err = %v, want it to wrap ErrNoServer", err)
+	}
+}

--- a/internal/tmux/ops.go
+++ b/internal/tmux/ops.go
@@ -23,11 +23,17 @@ func CapturePane(r Runner, target string) (string, error) {
 // this, and SGR escapes interleaved with the text would break those matches
 // wherever the pane happens to have colored a word mid-marker.
 func CapturePanePlain(r Runner, target string) (string, error) {
-	out, err := r.Run("capture-pane", "-p", "-t", target)
+	out, err := r.Run(CapturePanePlainArgs(target)...)
 	if err != nil {
 		return "", fmt.Errorf("capturing pane %q: %w (%s)", target, err, out)
 	}
 	return out, nil
+}
+
+// CapturePanePlainArgs is CapturePanePlain's command, for callers assembling a
+// batch of captures rather than issuing one — see RunOutputsTolerant.
+func CapturePanePlainArgs(target string) []string {
+	return []string{"capture-pane", "-p", "-t", target}
 }
 
 // KillWindow removes a window by its window ID (e.g. "@2").

--- a/internal/tui/agents.go
+++ b/internal/tui/agents.go
@@ -57,7 +57,11 @@ func loadAgentStatus(r tmux.Runner, profiles []agent.Profile, skipPane string) t
 			windows:  map[string]agent.State{},
 			sessions: map[string]agent.State{},
 		}
-		captures := 0
+		// Pick the panes worth reading first, then read them all at once. The
+		// captures are independent of one another, so on a Runner that batches
+		// this is a single tmux process instead of up to maxAgentCaptures of
+		// them, every listRefreshInterval, for as long as the TUI is open.
+		var candidates []tmux.PaneRef
 		for _, ref := range refs {
 			if !agent.IsAgentPane(ref.Command, profiles) {
 				continue
@@ -68,17 +72,29 @@ func loadAgentStatus(r tmux.Runner, profiles []agent.Profile, skipPane string) t
 			if skipPane != "" && ref.PaneID == skipPane {
 				continue
 			}
-			if captures >= maxAgentCaptures {
+			if len(candidates) >= maxAgentCaptures {
 				break
 			}
-			captures++
-			content, err := tmux.CapturePanePlain(r, ref.PaneID)
-			if err != nil {
-				// A pane that died between listing and capturing is ordinary;
-				// leave it unmarked and carry on with the rest.
+			candidates = append(candidates, ref)
+		}
+		if len(candidates) == 0 {
+			return agentStatusMsg{status: status}
+		}
+
+		cmds := make([][]string, len(candidates))
+		for i, ref := range candidates {
+			cmds[i] = tmux.CapturePanePlainArgs(ref.PaneID)
+		}
+		// A pane that died between listing and capturing is ordinary, and it
+		// stops a batch short — so the ones it cut off are read individually
+		// rather than lost. Panes with no capture simply stay unmarked.
+		contents, _ := tmux.RunOutputsTolerant(r, cmds)
+
+		for i, ref := range candidates {
+			if i >= len(contents) || contents[i] == "" {
 				continue
 			}
-			state := agent.Detect(ref.Command, content, profiles)
+			state := agent.Detect(ref.Command, contents[i], profiles)
 			// Unknown is stored nowhere: it draws no marker and must not win a
 			// rollup, and leaving it out keeps the maps to panes worth showing.
 			if state == agent.StateNone || state == agent.StateUnknown {

--- a/internal/tui/agents_test.go
+++ b/internal/tui/agents_test.go
@@ -328,3 +328,83 @@ func TestListAllPanesNoServer(t *testing.T) {
 		t.Errorf("no server should be an empty result, got %v / %v", refs, err)
 	}
 }
+
+// batchingAgentRunner answers capture-pane in batches, so a test can see that
+// the scan reads every pane in one process rather than one process per pane.
+type batchingAgentRunner struct {
+	funcRunner
+	batches  int
+	direct   int
+	failPane string
+}
+
+func (b *batchingAgentRunner) Run(args ...string) (string, error) {
+	if args[0] == "capture-pane" {
+		b.direct++
+	}
+	return b.funcRunner.Run(args...)
+}
+
+func (b *batchingAgentRunner) RunBatch(cmds [][]string) ([]string, error) {
+	b.batches++
+	outs := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		if b.failPane != "" && c[len(c)-1] == b.failPane {
+			return outs, errors.New("can't find pane")
+		}
+		out, err := b.funcRunner.Run(c...)
+		if err != nil {
+			return outs, err
+		}
+		outs = append(outs, out)
+	}
+	return outs, nil
+}
+
+// The scan runs every listRefreshInterval for as long as the TUI is open, so
+// reading N panes used to cost N tmux processes on a timer. Now it costs one.
+func TestAgentScanBatchesCaptures(t *testing.T) {
+	r := &batchingAgentRunner{funcRunner: agentRunner(
+		"$1|@1|%1|claude\n$1|@1|%2|claude\n$1|@2|%3|claude\n$1|@2|%4|zsh\n",
+		map[string]string{"%1": waitingPane, "%2": workingPane, "%3": donePane},
+	)}
+
+	status := run(loadAgentStatus(r, nil, "")).(agentStatusMsg).status
+	if r.batches != 1 {
+		t.Errorf("issued %d batches, want 1", r.batches)
+	}
+	if r.direct != 0 {
+		t.Errorf("issued %d capture-pane calls outside the batch, want 0", r.direct)
+	}
+	// The shell pane is never captured, so the batch holds only the agents.
+	if got := status.pane("%1"); got != agent.StateBlocked {
+		t.Errorf("%%1 = %v, want blocked", got)
+	}
+	if got := status.pane("%3"); got != agent.StateIdle {
+		t.Errorf("%%3 = %v, want idle", got)
+	}
+}
+
+// A pane that closed between the listing and the capture stops the batch there.
+// The panes after it must still be read, or one dead pane would blank every
+// marker behind it.
+func TestAgentScanSurvivesAPaneDyingMidBatch(t *testing.T) {
+	r := &batchingAgentRunner{
+		funcRunner: agentRunner(
+			"$1|@1|%1|claude\n$1|@1|%2|claude\n$1|@2|%3|claude\n",
+			map[string]string{"%1": waitingPane, "%3": donePane},
+		),
+		failPane: "%2",
+	}
+
+	status := run(loadAgentStatus(r, nil, "")).(agentStatusMsg).status
+	if got := status.pane("%1"); got != agent.StateBlocked {
+		t.Errorf("%%1 = %v, want blocked (it was read before the failure)", got)
+	}
+	if got := status.pane("%3"); got != agent.StateIdle {
+		t.Errorf("%%3 = %v, want idle (it must be replayed after the failure)", got)
+	}
+	if got := status.pane("%2"); got != agent.StateNone {
+		t.Errorf("%%2 = %v, want none — the pane is gone", got)
+	}
+}


### PR DESCRIPTION
Collapses wyrm's tmux calls into batched invocations. Measured against a real
tmux server on a three-window, six-pane config: **20 processes → 9**.

## How it works

tmux takes several commands in one invocation, separated by a literal `;` argv
element (no shell involved). Three constraints shaped the design:

1. **A batch stops at its first failure.** That collides with
   `internal/session`'s documented "warn and continue" policy — naively batching
   turns one broken command into "and everything after it silently didn't
   happen."
2. **`send-keys` prints nothing**, so output alone can't say how far a batch
   got. A marker is emitted after each command and counted: `N` markers means
   `N` succeeded and `cmds[N]` is where it stopped. The marker is randomized per
   batch, because the output being delimited contains user-controlled session
   and window names.
3. **Replay must resume *at* the failure, never before it.** Re-issuing a
   `send-keys` that already landed would type its text into the pane a second
   time — worse than the failure being recovered from.

`tmux.BatchRunner` is an *optional* interface reached through `tmux.RunEach` /
`tmux.RunOutputsTolerant`, which fall back to one call each. So no test double
changed, and `DryRun` deliberately does not implement it — `wyrm up -n` still
prints one line per tmux command.

## What's batched

| | before | after |
|---|---|---|
| session build (6 panes) | 20 processes | 9 |
| TUI agent scan, per 3s tick | up to 17 | 2 |

The data-dependent `split-window` chain is deliberately **not** batched: it
would mean replacing explicit `-t` targeting with tmux's implicit "current pane"
cursor, in the one package whose whole design is targeting by ID.

## Also fixed

`go.mod` still required `golang.org/x/term` after `internal/picker` was removed
in 0.6.0. CI now fails on an untidy `go.mod`.

## Verification

- New real-tmux test counts actual process spawns through a batching Runner and
  a non-batching one, and asserts both produce identical sessions.
- Mid-batch failure covered at both levels: a dead pane must not cancel the
  commands behind it, and nothing may be issued twice.
- Full suite, `-race`, `-short`, lint, and `govulncheck` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
