### PR TITLE
Add man page and native Linux packaging (deb/rpm/AUR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,9 @@ jobs:
         run: |
           set -euo pipefail
           wyrm version
-          test -f /usr/share/man/man1/wyrm.1
+          # makepkg's default `zipman` option gzips man pages during
+          # packaging, so the installed file is wyrm.1.gz, not wyrm.1.
+          test -f /usr/share/man/man1/wyrm.1.gz -o -f /usr/share/man/man1/wyrm.1
           test -f /usr/share/bash-completion/completions/wyrm
           pacman -Q tmux
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,85 @@ jobs:
           distribution: goreleaser
           version: "~> 2"
           args: release --snapshot --clean --skip=publish
+      # test-rpm-install and test-arch-install install from these artifacts, so a
+      # packaging mistake (missing file in `contents:`, a bad `depends`) is caught
+      # here rather than at tag time on a real release.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  # The .rpm from the nfpm block (see .goreleaser.yaml) is only ever
+  # exercised by `dnf install` for real at release time otherwise — this
+  # installs the snapshot build's .rpm on Fedora and checks the result runs.
+  test-rpm-install:
+    name: Install snapshot .rpm on Fedora
+    needs: release-dry-run
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: dnf install the built rpm
+        run: |
+          set -euo pipefail
+          rpm_file="$(ls dist/*.rpm | grep -v -E 'aarch64|arm64')"
+          dnf install -y --nogpgcheck "$rpm_file"
+      - name: Smoke test the installed package
+        run: |
+          set -euo pipefail
+          wyrm version
+          test -f /usr/share/man/man1/wyrm.1
+          test -f /usr/share/bash-completion/completions/wyrm
+          rpm -q --recommends wyrm | grep -qi tmux
+
+  # Same idea for the AUR side: build packaging/aur/PKGBUILD with makepkg
+  # against this run's snapshot tarball (a local file:// source, standing in
+  # for the real GitHub release URL the tag-time job fills in) and install it,
+  # so a broken PKGBUILD is caught on every PR instead of at the next release.
+  test-arch-install:
+    name: Build and install PKGBUILD on Arch
+    needs: release-dry-run
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    steps:
+      # actions/checkout needs git, which base-devel doesn't include. Full
+      # -Syu (not just -Sy) here so the later dependency install makepkg -s
+      # triggers for tmux isn't a partial upgrade against a stale image.
+      - name: Install git
+        run: pacman -Syu --noconfirm git
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Point the PKGBUILD at this run's snapshot tarball
+        run: |
+          set -euo pipefail
+          tarball="$(ls dist/wyrm_*_linux_amd64.tar.gz | head -1)"
+          sha="$(sha256sum "$tarball" | awk '{print $1}')"
+          sed \
+            -e "s/^pkgver=.*/pkgver=0.0.0/" \
+            -e "s#^source_x86_64=.*#source_x86_64=(\"wyrm-bin-0.0.0-x86_64.tar.gz::file://${GITHUB_WORKSPACE}/${tarball}\")#" \
+            -e "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${sha}')/" \
+            packaging/aur/PKGBUILD > PKGBUILD
+      - name: makepkg -si (must run as a non-root user)
+        run: |
+          set -euo pipefail
+          useradd -m builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+          su builder -c "cd '$GITHUB_WORKSPACE' && makepkg -si --noconfirm"
+      - name: Smoke test the installed package
+        run: |
+          set -euo pipefail
+          wyrm version
+          test -f /usr/share/man/man1/wyrm.1
+          test -f /usr/share/bash-completion/completions/wyrm
+          pacman -Q tmux
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,11 @@ jobs:
         run: |
           set -euo pipefail
           wyrm version
-          # makepkg's default `zipman` option gzips man pages during
-          # packaging, so the installed file is wyrm.1.gz, not wyrm.1.
-          test -f /usr/share/man/man1/wyrm.1.gz -o -f /usr/share/man/man1/wyrm.1
+          echo "--- pkg/wyrm-bin (what makepkg packaged, pre-strip of build dir) ---"
+          find pkg/wyrm-bin -type f 2>&1 || true
+          echo "--- /usr/share/man and /usr/share/bash-completion (what's actually installed) ---"
+          find /usr/share/man /usr/share/bash-completion -type f 2>&1 || true
+          find /usr/share/man/man1 -maxdepth 1 -name 'wyrm.1*' | grep -q .
           test -f /usr/share/bash-completion/completions/wyrm
           pacman -Q tmux
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,13 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:base-devel
     steps:
+      # The archlinux Docker image's pacman.conf sets NoExtract on
+      # usr/share/man/* (and similar docs) for every package, to keep the
+      # image small — a real Arch install doesn't have this, so without
+      # removing it here the smoke test's man-page check would fail for an
+      # environment reason that has nothing to do with the PKGBUILD.
+      - name: Let this image actually install man pages
+        run: sed -i '/^NoExtract/d' /etc/pacman.conf
       # actions/checkout needs git, which base-devel doesn't include. Full
       # -Syu (not just -Sy) here so the later dependency install makepkg -s
       # triggers for tmux isn't a partial upgrade against a stale image.
@@ -134,10 +141,8 @@ jobs:
         run: |
           set -euo pipefail
           wyrm version
-          echo "--- pkg/wyrm-bin (what makepkg packaged, pre-strip of build dir) ---"
-          find pkg/wyrm-bin -type f 2>&1 || true
-          echo "--- /usr/share/man and /usr/share/bash-completion (what's actually installed) ---"
-          find /usr/share/man /usr/share/bash-completion -type f 2>&1 || true
+          # makepkg's default `zipman` option gzips man pages during
+          # packaging, so match by prefix rather than the exact filename.
           find /usr/share/man/man1 -maxdepth 1 -name 'wyrm.1*' | grep -q .
           test -f /usr/share/bash-completion/completions/wyrm
           pacman -Q tmux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+  aur:
+    name: Publish AUR package
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # packaging/aur/PKGBUILD in the repo is a template (pkgver=0.0.0,
+      # zeroed checksums) — the real values come from this release's own
+      # checksums.txt so the AUR package's hashes are never hand-typed.
+      - name: Fill in PKGBUILD for this release
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          checksums="$(curl -fsSL "https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/checksums.txt")"
+          amd64_sum="$(printf '%s\n' "$checksums" | grep '_linux_amd64\.tar\.gz$' | awk '{print $1}')"
+          arm64_sum="$(printf '%s\n' "$checksums" | grep '_linux_arm64\.tar\.gz$' | awk '{print $1}')"
+          if [ -z "$amd64_sum" ] || [ -z "$arm64_sum" ]; then
+            echo "missing checksum for one or both linux archives in checksums.txt" >&2
+            exit 1
+          fi
+          sed \
+            -e "s/^pkgver=.*/pkgver=${version}/" \
+            -e "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${amd64_sum}')/" \
+            -e "s/^sha256sums_aarch64=.*/sha256sums_aarch64=('${arm64_sum}')/" \
+            packaging/aur/PKGBUILD > /tmp/PKGBUILD
+
+      - name: Publish to the AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+        with:
+          pkgname: wyrm-bin
+          pkgbuild: /tmp/PKGBUILD
+          commit_username: Josh Skoll
+          commit_email: jskoll@users.noreply.github.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "wyrm-bin ${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           pkgname: wyrm-bin
           pkgbuild: /tmp/PKGBUILD
-          commit_username: Josh Skoll
+          commit_username: Jason Skollingsberg
           commit_email: jskoll@users.noreply.github.com
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "wyrm-bin ${{ github.ref_name }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ nfpms:
     package_name: wyrm
     vendor: jskoll
     homepage: https://github.com/jskoll/wyrm
-    maintainer: "Josh Skoll <jskoll@users.noreply.github.com>"
+    maintainer: "Jason Skollingsberg <jskoll@users.noreply.github.com>"
     description: "Repeatable tmux session layouts from a TOML config"
     license: MIT
     formats: [deb, rpm]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,38 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - completions/*
+      - man/wyrm.1
+      - LICENSE
+      - README.md
 
 checksum:
   name_template: checksums.txt
+
+nfpms:
+  - id: wyrm
+    package_name: wyrm
+    vendor: jskoll
+    homepage: https://github.com/jskoll/wyrm
+    maintainer: "Josh Skoll <jskoll@users.noreply.github.com>"
+    description: "Repeatable tmux session layouts from a TOML config"
+    license: MIT
+    formats: [deb, rpm]
+    section: utils
+    recommends:
+      - tmux
+    contents:
+      - src: completions/wyrm.bash
+        dst: /usr/share/bash-completion/completions/wyrm
+      - src: completions/_wyrm
+        dst: /usr/share/zsh/site-functions/_wyrm
+      - src: completions/wyrm.fish
+        dst: /usr/share/fish/vendor_completions.d/wyrm.fish
+      - src: man/wyrm.1
+        dst: /usr/share/man/man1/wyrm.1
+      - src: LICENSE
+        dst: /usr/share/doc/wyrm/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/wyrm/README.md
 
 changelog:
   use: github
@@ -40,3 +69,4 @@ brews:
       bash_completion.install "completions/wyrm.bash" => "wyrm"
       zsh_completion.install "completions/_wyrm"
       fish_completion.install "completions/wyrm.fish"
+      man1.install "man/wyrm.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- A `wyrm(1)` man page, installed by the Homebrew formula and the new
+  `.deb`/`.rpm` packages built via `nfpm`.
+- Native Linux packaging: tagged releases now build `.deb` and `.rpm`
+  packages (with the completions and man page baked in) alongside the
+  existing tarballs, and publish a `wyrm-bin` package to the AUR.
+
 ### Changed
 - Internal: the TUI's panels are described by one table (`internal/tui/panels.go`)
   instead of nine parallel switch statements spread across four files. Title,

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ name = "code"
 brew install jskoll/tap/wyrm
 ```
 
+On Arch Linux, from the AUR:
+
+```sh
+yay -S wyrm-bin   # or: paru -S wyrm-bin
+```
+
+On Debian/Ubuntu or Fedora/RHEL, grab the `.deb`/`.rpm` from the
+[latest release](https://github.com/jskoll/wyrm/releases/latest) and install
+it directly:
+
+```sh
+sudo dpkg -i wyrm_*_linux_amd64.deb        # Debian/Ubuntu
+sudo dnf install ./wyrm_*_linux_amd64.rpm  # Fedora/RHEL
+```
+
 Or via Go:
 
 ```sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,21 @@ name = "code"
 brew install jskoll/tap/wyrm
 ```
 
+On Arch Linux, from the AUR:
+
+```sh
+yay -S wyrm-bin   # or: paru -S wyrm-bin
+```
+
+On Debian/Ubuntu or Fedora/RHEL, grab the `.deb`/`.rpm` from the
+[latest release](https://github.com/jskoll/wyrm/releases/latest) and install
+it directly:
+
+```sh
+sudo dpkg -i wyrm_*_linux_amd64.deb        # Debian/Ubuntu
+sudo dnf install ./wyrm_*_linux_amd64.rpm  # Fedora/RHEL
+```
+
 Or via Go:
 
 ```sh

--- a/man/wyrm.1
+++ b/man/wyrm.1
@@ -185,4 +185,4 @@ List running sessions as JSON for a script:
 Full documentation and the configuration reference:
 .B https://jskoll.github.io/wyrm/
 .SH AUTHOR
-Josh Skoll and contributors.
+Jason Skollingsberg and contributors.

--- a/man/wyrm.1
+++ b/man/wyrm.1
@@ -1,0 +1,188 @@
+.TH WYRM 1 "2026" "wyrm" "User Commands"
+.SH NAME
+wyrm \- repeatable tmux session layouts from a TOML config
+.SH SYNOPSIS
+.B wyrm
+.RI [ \-config
+.IR PATH ]
+.br
+.B wyrm
+.I COMMAND
+.RI [ ARGS ...]
+.SH DESCRIPTION
+.B wyrm
+builds tmux sessions from a
+.B .wyrm.toml
+config file: nested split trees, lifecycle hooks, and pane-ID targeting so
+layouts come out the same regardless of
+.B base\-index
+/
+.B pane\-base\-index
+settings. Running
+.B wyrm
+with no arguments builds (or attaches to) the session for the config
+discovered in the current directory; see
+.B FILES
+for the discovery order.
+.SH COMMANDS
+.TP
+.BI "wyrm [\-config " PATH ]
+Build or attach the current folder's session. This is the default
+when no subcommand is given.
+.TP
+.BI "wyrm up [\-config " PATH "] [\-n]"
+Same as bare
+.BR wyrm ,
+spelled explicitly.
+.TP
+.BI "wyrm " NAME
+Attach to a running session named
+.I NAME
+if one exists; otherwise start the known project named
+.I NAME
+(local or shared config).
+.TP
+.BI "wyrm restart [\-config " PATH "] [\-n]"
+Stop the session (running
+.B on_project_exit
+first) and build it again from the current config.
+.TP
+.BI "wyrm kill [" NAME "] [\-config " PATH "] [\-n]"
+Destroy the session, running
+.B on_project_exit
+first. With no name, targets the current folder's session; with
+.IR NAME ,
+targets that session (or known project) instead.
+.B \-config
+and a session name are mutually exclusive.
+.TP
+.B wyrm pick
+Fuzzy-pick a running session and attach to it.
+.TP
+.B wyrm tui
+Open the full-screen session manager: browse, preview, kill, rename, and
+start sessions.
+.TP
+.BI "wyrm save [\-config " PATH ]
+Save the running session's current layout as this folder's config.
+Refuses to overwrite an existing config file.
+.TP
+.BI "wyrm edit [\-config " PATH ]
+Open the resolved config in
+.B $EDITOR
+(falling back to
+.BR vi ),
+creating one at the discovery location if none exists yet.
+.TP
+.BI "wyrm validate [\-config " PATH "] [\-strict]"
+Check that the effective config parses and validates, without building a
+session.
+.B \-strict
+exits non-zero if the config has warnings (typos, deprecations).
+.TP
+.BI "wyrm list [\-format " FMT ]
+List running tmux sessions non-interactively.
+.I FMT
+is one of
+.BR table " (default), " json ", " toml ", or " names .
+.TP
+.B wyrm list-configs
+List candidate config file paths: the local file (if present) and every
+config in the shared config directory. Used by shell completion.
+.TP
+.B wyrm migrate-config
+Move the local config file into the shared config directory.
+.TP
+.B wyrm version
+Print the version and exit.
+.TP
+.B wyrm help
+Show a usage overview.
+.PP
+Run any subcommand with
+.B \-h
+to see its own flags.
+.SH OPTIONS
+.TP
+.BI \-config " PATH"
+Path to the config file to use, overriding discovery. Accepted by
+.BR up ", " restart ", " kill ", " save ", " edit ", and " validate .
+.TP
+.B \-n
+Dry run: print the tmux commands and lifecycle hooks that would run,
+without touching tmux. Accepted by
+.BR up ", " restart ", and " kill .
+.TP
+.B \-strict
+With
+.BR validate ,
+exit non-zero if the config has warnings instead of just printing them.
+.TP
+.BI \-format " FMT"
+With
+.BR list ,
+select the output format:
+.BR table ", " json ", " toml ", or " names .
+.SH FILES
+.TP
+.B .wyrm.toml
+The config file wyrm looks for first in the current directory.
+.TP
+.B .tmuxconfig
+Deprecated legacy config name, still read if
+.B .wyrm.toml
+is absent.
+.TP
+.B $XDG_CONFIG_HOME/wyrm/settings.toml
+(falls back to
+.BR ~/.config/wyrm/settings.toml )
+Global settings: local vs. shared config storage, the shared config
+directory, and TUI preferences.
+.TP
+.B $XDG_CONFIG_HOME/wyrm/default.wyrm.toml
+User-supplied replacement for the built-in default config, used when no
+local or shared config is found.
+.TP
+.BI $XDG_CONFIG_HOME/wyrm/ <folder> .wyrm.toml
+A project's config in the shared config directory, when
+.B storage = "shared"
+in the global settings. Populated by
+.B wyrm migrate-config
+or
+.BR "wyrm save" .
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+The command failed (e.g. no running session or known project by that
+name).
+.TP
+.B 2
+Usage error: a bad flag, an unknown
+.BR \-format ,
+or an unexpected argument.
+.SH EXAMPLES
+.TP
+Build or attach using the config in the current directory:
+.B wyrm
+.TP
+Preview what a build would do without touching tmux:
+.B wyrm up \-n
+.TP
+Attach to (or start) a project named "api" from anywhere:
+.B wyrm api
+.TP
+Tear a session down and rebuild it after editing its config:
+.B wyrm restart
+.TP
+List running sessions as JSON for a script:
+.B wyrm list \-format json
+.SH SEE ALSO
+.BR tmux (1)
+.br
+Full documentation and the configuration reference:
+.B https://jskoll.github.io/wyrm/
+.SH AUTHOR
+Josh Skoll and contributors.

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Josh Skoll <jskoll@users.noreply.github.com>
+#
+# Template only — pkgver/pkgrel/sha256sums here are placeholders. The
+# release workflow (.github/workflows/aur.yml) fills them in from the
+# tagged release's checksums.txt and pushes the result to the AUR; this
+# file in the main repo is never updated by CI, so it always reads
+# "next release, unfilled" rather than drifting from the last publish.
+pkgname=wyrm-bin
+pkgver=0.0.0
+pkgrel=1
+pkgdesc="Repeatable tmux session layouts from a TOML config"
+arch=('x86_64' 'aarch64')
+url="https://github.com/jskoll/wyrm"
+license=('MIT')
+depends=('tmux')
+provides=('wyrm')
+conflicts=('wyrm')
+source_x86_64=("$pkgname-$pkgver-x86_64.tar.gz::https://github.com/jskoll/wyrm/releases/download/v$pkgver/wyrm_${pkgver}_linux_amd64.tar.gz")
+source_aarch64=("$pkgname-$pkgver-aarch64.tar.gz::https://github.com/jskoll/wyrm/releases/download/v$pkgver/wyrm_${pkgver}_linux_arm64.tar.gz")
+sha256sums_x86_64=('0000000000000000000000000000000000000000000000000000000000000000')
+sha256sums_aarch64=('0000000000000000000000000000000000000000000000000000000000000000')
+
+package() {
+  cd "$srcdir"
+  install -Dm755 wyrm "$pkgdir/usr/bin/wyrm"
+  install -Dm644 man/wyrm.1 "$pkgdir/usr/share/man/man1/wyrm.1"
+  install -Dm644 completions/wyrm.bash "$pkgdir/usr/share/bash-completion/completions/wyrm"
+  install -Dm644 completions/_wyrm "$pkgdir/usr/share/zsh/site-functions/_wyrm"
+  install -Dm644 completions/wyrm.fish "$pkgdir/usr/share/fish/vendor_completions.d/wyrm.fish"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Josh Skoll <jskoll@users.noreply.github.com>
+# Maintainer: Jason Skollingsberg <jskoll@users.noreply.github.com>
 #
 # Template only — pkgver/pkgrel/sha256sums here are placeholders. The
 # release workflow (.github/workflows/aur.yml) fills them in from the


### PR DESCRIPTION
Adds a wyrm(1) man page, an nfpm block in .goreleaser.yaml that builds
.deb and .rpm packages (binary, completions, man page, license/readme)
on every tagged release, and a wyrm-bin AUR package published by a new
CI job that fills in the PKGBUILD template's version and checksums
from the release's checksums.txt.