### PR TITLE
fix(agent): prevent PowerShell command injection in Windows desktop notifications

### DIFF
--- a/internal/agent/notify.go
+++ b/internal/agent/notify.go
@@ -112,6 +112,31 @@ func Dispatch(n Notification, cfg NotifyConfig, out io.Writer) error {
 	return nil
 }
 
+// WindowsToastScript is the PowerShell script used to display Windows toast notifications
+// without string interpolation vulnerabilities.
+const WindowsToastScript = `
+$title = $env:WYRM_NOTIFY_TITLE
+$msg = $env:WYRM_NOTIFY_MSG
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null
+$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+$textNodes = $template.GetElementsByTagName('text')
+$textNodes.Item(0).AppendChild($template.CreateTextNode($title)) > $null
+$textNodes.Item(1).AppendChild($template.CreateTextNode($msg)) > $null
+$toast = [Windows.UI.Notifications.ToastNotification]::new($template)
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Wyrm').Show($toast)
+`
+
+// BuildWindowsToastCommand constructs an exec.Cmd for PowerShell Windows toast notifications
+// safely passing title and message through environment variables to prevent command injection.
+func BuildWindowsToastCommand(title, msg string) *exec.Cmd {
+	cmd := exec.Command("powershell", "-NoProfile", "-Command", WindowsToastScript)
+	cmd.Env = append(os.Environ(),
+		"WYRM_NOTIFY_TITLE="+title,
+		"WYRM_NOTIFY_MSG="+msg,
+	)
+	return cmd
+}
+
 // SendDesktopNotification invokes platform desktop notification tools.
 // Swappable for testing.
 var SendDesktopNotification = func(title, msg string) {
@@ -122,7 +147,7 @@ var SendDesktopNotification = func(title, msg string) {
 	case "linux", "freebsd", "openbsd", "netbsd":
 		_ = exec.Command("notify-send", title, msg).Run()
 	case "windows":
-		psScript := fmt.Sprintf(`[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null; $template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); $textNodes = $template.GetElementsByTagName('text'); $textNodes.Item(0).AppendChild($template.CreateTextNode('%s')) > $null; $textNodes.Item(1).AppendChild($template.CreateTextNode('%s')) > $null; $toast = [Windows.UI.Notifications.ToastNotification]::new($template); [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Wyrm').Show($toast)`, title, msg)
-		_ = exec.Command("powershell", "-NoProfile", "-Command", psScript).Run()
+		cmd := BuildWindowsToastCommand(title, msg)
+		_ = cmd.Run()
 	}
 }

--- a/internal/agent/notify_test.go
+++ b/internal/agent/notify_test.go
@@ -130,3 +130,70 @@ func TestDispatchDesktop(t *testing.T) {
 		t.Errorf("desktopMsg = %q, want mentioning dev (%%5)", desktopMsg)
 	}
 }
+
+func TestBuildWindowsToastCommand_SafeEnvironmentVariables(t *testing.T) {
+	maliciousTitle := `test'); Start-Process calc.exe; ('`
+	maliciousMsg := `msg"; Invoke-Item C:\; "`
+
+	cmd := BuildWindowsToastCommand(maliciousTitle, maliciousMsg)
+
+	// Command line arguments must be static and not contain user input directly
+	for _, arg := range cmd.Args {
+		if strings.Contains(arg, "calc.exe") {
+			t.Errorf("PowerShell args contained unescaped payload: %s", arg)
+		}
+		if strings.Contains(arg, maliciousTitle) {
+			t.Errorf("PowerShell args contained raw title: %s", arg)
+		}
+	}
+
+	// Environment variables must safely carry the values
+	var foundTitle, foundMsg bool
+	for _, env := range cmd.Env {
+		if env == "WYRM_NOTIFY_TITLE="+maliciousTitle {
+			foundTitle = true
+		}
+		if env == "WYRM_NOTIFY_MSG="+maliciousMsg {
+			foundMsg = true
+		}
+	}
+
+	if !foundTitle {
+		t.Errorf("WYRM_NOTIFY_TITLE not properly set in environment")
+	}
+	if !foundMsg {
+		t.Errorf("WYRM_NOTIFY_MSG not properly set in environment")
+	}
+}
+
+func TestBuildWindowsToastCommand_SpecialCharacters(t *testing.T) {
+	specialCases := []struct {
+		name  string
+		title string
+		msg   string
+	}{
+		{"single quotes", "It's a test", "Don't break 'PowerShell'"},
+		{"double quotes", `He said "hello"`, `Nested "quotes"`},
+		{"semicolons and pipes", "title; echo pwned | cat", "msg & echo hi"},
+		{"variable expansion", "Value is $HOME and $env:SECRET", "Payload `$((Get-Process).Count)"},
+		{"backticks", "Use `code` blocks", "tick ` ` `"},
+	}
+
+	for _, tc := range specialCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := BuildWindowsToastCommand(tc.title, tc.msg)
+			var foundTitle, foundMsg bool
+			for _, env := range cmd.Env {
+				if env == "WYRM_NOTIFY_TITLE="+tc.title {
+					foundTitle = true
+				}
+				if env == "WYRM_NOTIFY_MSG="+tc.msg {
+					foundMsg = true
+				}
+			}
+			if !foundTitle || !foundMsg {
+				t.Errorf("special characters not preserved in environment for case %s", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
This PR resolves [SEC-01] (Issue #9) by passing notification `title` and `msg` through environment variables (`WYRM_NOTIFY_TITLE` and `WYRM_NOTIFY_MSG`) in PowerShell toast notifications rather than interpolating them directly into the PowerShell command script string.

### Changes
- Implemented `BuildWindowsToastCommand` and `SendDesktopNotification` in `internal/agent/notify.go` using environment variables.
- Added comprehensive unit tests in `internal/agent/notify_test.go` ensuring single quotes, metacharacters, backticks, and subcommands cannot cause PowerShell script injection.

Fixes #9