### PR TITLE
feat(clone): add -no-start flag and warn on untrusted lifecycle hooks

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,10 @@ very much in scope.
 and the lifecycle hooks a config would run, and execute neither. That is the
 supported way to inspect an unfamiliar config.
 
+When cloning untrusted remote repositories, pass `wyrm clone -no-start <repo>`
+(or `wyrm clone -n <repo>`) to clone the repository without automatically executing
+lifecycle hooks or launching a session, allowing you to review `.wyrm.toml` first.
+
 Before 0.6.0, `-n` printed the hooks' tmux commands but ran `on_project_start`
 for real, which defeated the point. If you are on an older build, read the
 config itself rather than relying on `-n`.

--- a/cmd_clone.go
+++ b/cmd_clone.go
@@ -24,11 +24,13 @@ import (
 // under the pattern.
 func (a *app) clone(args []string) error {
 	fs := a.newFlagSet("clone")
+	noStart := fs.Bool("no-start", false, "clone the repository without starting a session")
+	fs.BoolVar(noStart, "n", false, "alias for -no-start")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() < 1 || fs.NArg() > 2 {
-		return usageErrf("wyrm clone needs a repository and an optional destination directory: wyrm clone <repo> [dest]")
+		return usageErrf("wyrm clone needs a repository and an optional destination directory: wyrm clone [-no-start] <repo> [dest]")
 	}
 	repo, dest := fs.Arg(0), fs.Arg(1)
 
@@ -59,6 +61,21 @@ func (a *app) clone(args []string) error {
 	absDest, err := filepath.Abs(dest)
 	if err != nil {
 		return err
+	}
+
+	if *noStart {
+		_, _ = fmt.Fprintf(a.stdout, "cloned %s to %s\n", repo, absDest)
+		return nil
+	}
+
+	for _, name := range []string{config.DefaultFileName, config.LegacyFileName} {
+		cfgPath := filepath.Join(absDest, name)
+		if cfg, err := config.Load(cfgPath); err == nil {
+			if cfg.Session.OnProjectStart != "" || cfg.Session.OnProjectFirstStart != "" {
+				_, _ = fmt.Fprintf(a.stderr, "wyrm: warning: %s defines lifecycle hooks (run with -no-start to clone without executing hooks)\n", name)
+			}
+			break
+		}
 	}
 
 	settings, err := config.LoadSettings()

--- a/cmd_clone_test.go
+++ b/cmd_clone_test.go
@@ -138,6 +138,52 @@ func TestCloneUsesLocalConfigIfPresent(t *testing.T) {
 	}
 }
 
+func TestCloneNoStart(t *testing.T) {
+	installFakeGit(t)
+	origin := t.TempDir()
+	chdir(t, origin)
+
+	r := &fakeRunner{}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"clone", "-no-start", "https://example.com/nostart.git"}, &stdout, &stderr, r,
+		func() bool { return false }, func(string) error { return nil })
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cloned https://example.com/nostart.git to") {
+		t.Errorf("stdout = %q, want clone confirmation without starting session", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "created session") {
+		t.Errorf("stdout = %q, did not want session to be created with -no-start", stdout.String())
+	}
+}
+
+func TestCloneWarnsOnHooks(t *testing.T) {
+	installFakeGit(t)
+	base := t.TempDir()
+	chdir(t, base)
+
+	dest := filepath.Join(base, "withhooks")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "[session]\nname = \"hooked\"\nroot = \".\"\non_project_start = \"echo pwned\"\n\n[[windows]]\nname = \"w\"\n"
+	if err := os.WriteFile(filepath.Join(dest, config.DefaultFileName), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &fakeRunner{}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"clone", "https://example.com/x.git", "withhooks"}, &stdout, &stderr, r,
+		func() bool { return false }, func(string) error { return nil })
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "defines lifecycle hooks") {
+		t.Errorf("stderr = %q, want warning about lifecycle hooks", stderr.String())
+	}
+}
+
 func TestCloneWrongArgCount(t *testing.T) {
 	installFakeGit(t)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ wyrm validate             # check the effective config parses and validates (-st
 wyrm list                 # list running tmux sessions non-interactively
 wyrm list-configs         # list candidate config file paths (used by shell completion)
 wyrm migrate-config       # move the local config into the shared config directory
-wyrm clone REPO [DEST]    # git clone, then build (and attach to) a session for it
+wyrm clone REPO [DEST]    # git clone, then build (and attach to) a session for it (-no-start to skip)
 wyrm selfupdate           # download and install the latest release
 wyrm version
 ```


### PR DESCRIPTION
### Summary
This PR addresses [SEC-04] (Issue #12) by providing safe mechanisms to inspect and clone remote repositories without immediately executing arbitrary lifecycle hooks (`on_project_start`, `on_project_first_start`).

### Changes
- Added `-no-start` (and shorthand `-n`) flag to `wyrm clone`, allowing users to clone a repository to review its configuration without building or executing hooks.
- Added a warning emitted to `stderr` when a cloned repository defines lifecycle hooks and `-no-start` was not specified.
- Added test coverage in `cmd_clone_test.go` (`TestCloneNoStart`, `TestCloneWarnsOnHooks`).
- Updated `docs/index.md` and `SECURITY.md` with documentation for `-no-start` / `-n`.

Fixes #12