### PR TITLE
fix(config): ensure deterministic and boundary-safe template variable substitution

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -507,19 +508,67 @@ func interpolateSplits(splits []Split, vars map[string]string) {
 	}
 }
 
-// InterpolateString substitutes template variables in s.
+// InterpolateString performs deterministic, boundary-safe template variable substitution.
+// It supports {{.var}}, {{var}}, {{.var.name}}, {{var.name}}, ${var}, and bare $var identifiers.
 func InterpolateString(s string, vars map[string]string) string {
 	if s == "" || len(vars) == 0 {
 		return s
 	}
+
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	// Sort keys by descending length first, then alphabetically, ensuring deterministic substitution
+	// and that longer prefixes are replaced before shorter substrings.
+	sort.Slice(keys, func(i, j int) bool {
+		if len(keys[i]) != len(keys[j]) {
+			return len(keys[i]) > len(keys[j])
+		}
+		return keys[i] < keys[j]
+	})
+
 	res := s
-	for k, v := range vars {
-		res = strings.ReplaceAll(res, "{{."+k+"}}", v)
-		res = strings.ReplaceAll(res, "{{"+k+"}}", v)
+	for _, k := range keys {
+		v := vars[k]
 		res = strings.ReplaceAll(res, "{{.var."+k+"}}", v)
 		res = strings.ReplaceAll(res, "{{var."+k+"}}", v)
+		res = strings.ReplaceAll(res, "{{."+k+"}}", v)
+		res = strings.ReplaceAll(res, "{{"+k+"}}", v)
 		res = strings.ReplaceAll(res, "${"+k+"}", v)
-		res = strings.ReplaceAll(res, "$"+k, v)
+		res = replaceBareVar(res, k, v)
 	}
 	return res
+}
+
+func isIdentChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+func replaceBareVar(s, k, v string) string {
+	target := "$" + k
+	if !strings.Contains(s, target) {
+		return s
+	}
+	var sb strings.Builder
+	targetLen := len(target)
+	i := 0
+	for i < len(s) {
+		idx := strings.Index(s[i:], target)
+		if idx == -1 {
+			sb.WriteString(s[i:])
+			break
+		}
+		pos := i + idx
+		sb.WriteString(s[i:pos])
+		nextIdx := pos + targetLen
+		if nextIdx < len(s) && isIdentChar(s[nextIdx]) {
+			// Next character continues an identifier (e.g. $PORT_SSL when matching $PORT), so keep as is
+			sb.WriteString(target)
+		} else {
+			sb.WriteString(v)
+		}
+		i = nextIdx
+	}
+	return sb.String()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -531,3 +531,67 @@ name = "legacy"
 		t.Errorf("Panes[0].Command = %q, want %q", cfg.Windows[1].Panes[0].Command, "ping localhost:8080")
 	}
 }
+
+func TestInterpolateString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		vars     map[string]string
+		expected string
+	}{
+		{
+			name:     "empty string and vars",
+			input:    "",
+			vars:     map[string]string{"foo": "bar"},
+			expected: "",
+		},
+		{
+			name:     "no vars",
+			input:    "echo $PORT",
+			vars:     nil,
+			expected: "echo $PORT",
+		},
+		{
+			name:  "delimited forms",
+			input: "{{PORT}} {{.PORT}} {{var.PORT}} {{.var.PORT}} ${PORT}",
+			vars: map[string]string{
+				"PORT": "8080",
+			},
+			expected: "8080 8080 8080 8080 8080",
+		},
+		{
+			name:  "prefix isolation with bare variable",
+			input: "connect to $PORT and $PORT_SSL or $PORT80 or $PORT/tcp",
+			vars: map[string]string{
+				"PORT": "8080",
+			},
+			expected: "connect to 8080 and $PORT_SSL or $PORT80 or 8080/tcp",
+		},
+		{
+			name:  "single character variable does not clobber words",
+			input: "$a and $app and $api and $a/path",
+			vars: map[string]string{
+				"a": "foo",
+			},
+			expected: "foo and $app and $api and foo/path",
+		},
+		{
+			name:  "deterministic long prefix matching over short prefix",
+			input: "$VARIABLE and $VAR",
+			vars: map[string]string{
+				"VAR":      "foo",
+				"VARIABLE": "bar",
+			},
+			expected: "bar and foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InterpolateString(tt.input, tt.vars)
+			if got != tt.expected {
+				t.Errorf("InterpolateString(%q, %v) = %q, want %q", tt.input, tt.vars, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
This PR resolves [SEC-06] (Issue #14) by ensuring that template variable substitutions performed via `InterpolateString` in `internal/config` are strictly deterministic and respect word/identifier boundaries.

### Changes
- Implemented `InterpolateString` with deterministic key sorting (descending length, then alphabetical) to eliminate nondeterminism from Go's randomized map iteration order.
- Implemented `replaceBareVar` ensuring bare `$var` references match only at identifier boundaries and do not clobber prefixes (e.g. `$PORT` will not corrupt `$PORT_SSL`).
- Added test coverage in `internal/config/config_test.go` (`TestInterpolateString`).

Fixes #14