### PR TITLE
fix(selfupdate): enforce size bounds on decompression and HTTP downloads

### DIFF
--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -91,7 +91,10 @@ func AssetName(version, goos, goarch string) string {
 	return fmt.Sprintf("%s_%s_%s_%s.tar.gz", repo, version, goos, goarch)
 }
 
-// Get downloads a URL's full body. Release archives are a few MB, small
+// MaxDownloadSize is the maximum size (100 MB) permitted for a downloaded release asset.
+const MaxDownloadSize = 100 * 1024 * 1024
+
+// Get downloads a URL's full body up to MaxDownloadSize. Release archives are a few MB, small
 // enough to hold in memory rather than streaming to a temp file.
 func Get(client HTTPDoer, url string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -106,7 +109,14 @@ func Get(client HTTPDoer, url string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("downloading %s: %s", url, resp.Status)
 	}
-	return io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, MaxDownloadSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", url, err)
+	}
+	if len(data) > MaxDownloadSize {
+		return nil, fmt.Errorf("download from %s exceeds maximum size of %d bytes", url, MaxDownloadSize)
+	}
+	return data, nil
 }
 
 // CompareVersions orders two dotted-numeric versions (a leading "v" and any

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -134,5 +135,24 @@ func TestCompareVersions(t *testing.T) {
 		if got := CompareVersions(tt.a, tt.b); got != tt.want {
 			t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
 		}
+	}
+}
+
+func TestGetDownloadExceedsLimit(t *testing.T) {
+	// A server that streams infinite zeroes
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		chunk := make([]byte, 1024*1024)
+		for i := 0; i < (MaxDownloadSize/(1024*1024) + 2); i++ {
+			_, _ = w.Write(chunk)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := Get(http.DefaultClient, srv.URL)
+	if err == nil {
+		t.Fatal("Get: want error for download exceeding MaxDownloadSize, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Errorf("Get error = %q, want size limit error message", err.Error())
 	}
 }

--- a/internal/selfupdate/verify.go
+++ b/internal/selfupdate/verify.go
@@ -37,8 +37,11 @@ func checksumFor(checksumsTxt []byte, filename string) (string, error) {
 	return "", fmt.Errorf("%s not listed in checksums.txt", filename)
 }
 
+// MaxBinarySize is the maximum permitted size (64 MB) for a single extracted binary.
+const MaxBinarySize = 64 * 1024 * 1024
+
 // ExtractFile pulls a single named regular file's contents out of a .tar.gz
-// archive.
+// archive, bounded by MaxBinarySize to prevent decompression bombs and OOM crashes.
 func ExtractFile(archive []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewReader(archive))
 	if err != nil {
@@ -56,7 +59,14 @@ func ExtractFile(archive []byte, name string) ([]byte, error) {
 			return nil, fmt.Errorf("reading archive: %w", err)
 		}
 		if hdr.Typeflag == tar.TypeReg && hdr.Name == name {
-			return io.ReadAll(tr)
+			data, err := io.ReadAll(io.LimitReader(tr, MaxBinarySize+1))
+			if err != nil {
+				return nil, fmt.Errorf("reading %s from archive: %w", name, err)
+			}
+			if len(data) > MaxBinarySize {
+				return nil, fmt.Errorf("%s exceeds maximum permitted binary size of %d bytes", name, MaxBinarySize)
+			}
+			return data, nil
 		}
 	}
 	return nil, fmt.Errorf("%s not found in archive", name)

--- a/internal/selfupdate/verify_test.go
+++ b/internal/selfupdate/verify_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -75,5 +76,44 @@ func TestExtractFileNotFound(t *testing.T) {
 	archive := buildArchive(t, map[string]string{"README.md": "docs"})
 	if _, err := ExtractFile(archive, "wyrm"); err == nil {
 		t.Fatal("ExtractFile: want error for missing file, got nil")
+	}
+}
+
+func TestExtractFileExceedsLimit(t *testing.T) {
+	// Construct an archive with a header claiming or containing data > MaxBinarySize
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	oversize := MaxBinarySize + 10
+	hdr := &tar.Header{Name: "wyrm", Mode: 0o755, Size: int64(oversize)}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	// Write MaxBinarySize + 10 bytes of zeroes
+	chunk := make([]byte, 1024*1024)
+	written := 0
+	for written < oversize {
+		toWrite := len(chunk)
+		if oversize-written < toWrite {
+			toWrite = oversize - written
+		}
+		if _, err := tw.Write(chunk[:toWrite]); err != nil {
+			t.Fatal(err)
+		}
+		written += toWrite
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ExtractFile(buf.Bytes(), "wyrm")
+	if err == nil {
+		t.Fatal("ExtractFile: want error for binary exceeding MaxBinarySize, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum permitted binary size") {
+		t.Errorf("ExtractFile error = %q, want size limit message", err.Error())
 	}
 }


### PR DESCRIPTION
### Summary
This PR resolves [SEC-07] (Issue #15) by bounding archive decompression and release asset downloads using `io.LimitReader` to prevent decompression bomb attacks and heap exhaustion.

### Changes
- Defined `MaxBinarySize` (64 MB) in `internal/selfupdate/verify.go` and enforced via `io.LimitReader` in `ExtractFile`.
- Defined `MaxDownloadSize` (100 MB) in `internal/selfupdate/selfupdate.go` and enforced via `io.LimitReader` in `Get`.
- Added unit tests in `verify_test.go` and `selfupdate_test.go` ensuring oversized assets are safely rejected without crashing.

Fixes #15