### PR TITLE
fix(config): prune hidden and dependency directories during recursive wildcard walks

### DIFF
--- a/internal/config/projects.go
+++ b/internal/config/projects.go
@@ -184,6 +184,10 @@ func matchWildcardDirs(pattern string) ([]string, error) {
 				return nil //nolint:nilerr
 			}
 			if path != base && d.IsDir() {
+				name := d.Name()
+				if strings.HasPrefix(name, ".") || isIgnoredWildcardDir(name) {
+					return filepath.SkipDir
+				}
 				dirs = append(dirs, path)
 			}
 			return nil
@@ -209,6 +213,20 @@ func matchWildcardDirs(pattern string) ([]string, error) {
 		}
 	}
 	return dirs, nil
+}
+
+var ignoredWildcardDirNames = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	"target":       true,
+	"dist":         true,
+	"build":        true,
+	"venv":         true,
+	"__pycache__":  true,
+}
+
+func isIgnoredWildcardDir(name string) bool {
+	return ignoredWildcardDirNames[name]
 }
 
 // FindProject returns the discoverable project whose session name is name,

--- a/internal/config/projects_test.go
+++ b/internal/config/projects_test.go
@@ -145,6 +145,12 @@ func TestDiscoverWildcardProjectsRecursive(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(base, "foo", "bar"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// Hidden directories and dependency directories that should be pruned
+	for _, ign := range []string{".git/objects", "node_modules/pkg", "vendor/sub", "foo/venv/bin"} {
+		if err := os.MkdirAll(filepath.Join(base, ign), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	settings := &Settings{Wildcard: []Wildcard{{Pattern: base + "/**", Config: template}}}
 	got := DiscoverWildcardProjects(settings)


### PR DESCRIPTION
### Summary
This PR addresses [SEC-10] (Issue #18) by pruning hidden directories and large dependency trees during recursive wildcard globbing in `internal/config`.

### Changes
- Updated `matchWildcardDirs` in `internal/config/projects.go` to skip hidden directories (names starting with `.`) and common build/dependency directories (`node_modules`, `vendor`, `target`, `dist`, `build`, `venv`, `__pycache__`).
- Added test coverage in `internal/config/projects_test.go` verifying that hidden and dependency subtrees are pruned.

Fixes #18