### PR TITLE
fix(state,config): use atomic file writes for persistence and config save

### DIFF
--- a/cmd_config.go
+++ b/cmd_config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jskoll/wyrm/internal/config"
 	"github.com/jskoll/wyrm/internal/editor"
 	"github.com/jskoll/wyrm/internal/freeze"
+	"github.com/jskoll/wyrm/internal/state"
 	"github.com/jskoll/wyrm/internal/tmux"
 	"github.com/pelletier/go-toml/v2"
 )
@@ -242,10 +243,7 @@ func (a *app) save(args []string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return err
-	}
-	if err := os.WriteFile(dest, data, 0o644); err != nil {
+	if err := state.AtomicWriteFile(dest, data, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -96,10 +96,37 @@ func (s *Store) save() error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
-		return err
+	return AtomicWriteFile(s.path, data, 0o644)
+}
+
+// AtomicWriteFile atomically writes data to path with the given mode by first writing
+// to a temporary file in path's parent directory and then renaming it over path.
+func AtomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating directory %s: %w", dir, err)
 	}
-	return os.WriteFile(s.path, data, 0o644)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing to %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", tmpPath, err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		return fmt.Errorf("chmod %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming %s to %s: %w", tmpPath, path, err)
+	}
+	return nil
 }
 
 // statePath returns the path to the state file, honoring $XDG_CONFIG_HOME

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -124,3 +124,35 @@ func TestLoadParseError(t *testing.T) {
 		t.Error("Load with malformed state file: want error, got nil")
 	}
 }
+
+func TestAtomicWriteFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "atomic.txt")
+
+	data := []byte("hello atomic world")
+	if err := AtomicWriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("AtomicWriteFile: %v", err)
+	}
+
+	read, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(read) != string(data) {
+		t.Errorf("read %q, want %q", read, data)
+	}
+
+	// Overwrite atomically
+	newData := []byte("updated content")
+	if err := AtomicWriteFile(path, newData, 0o644); err != nil {
+		t.Fatalf("second AtomicWriteFile: %v", err)
+	}
+
+	read2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("second ReadFile: %v", err)
+	}
+	if string(read2) != string(newData) {
+		t.Errorf("second read %q, want %q", read2, newData)
+	}
+}


### PR DESCRIPTION
### Summary
This PR resolves [SEC-11] (Issue #19) by implementing atomic file writes via temporary file creation and POSIX rename across state persistence and config saves.

### Changes
- Implemented `AtomicWriteFile` in `internal/state/state.go`.
- Replaced direct `os.WriteFile` in `Store.save()` and `cmd_config.go` (`wyrm save`) with `AtomicWriteFile`.
- Added `TestAtomicWriteFile` in `internal/state/state_test.go`.

Fixes #19