### PR TITLE
fix(selfupdate): configure explicit 30s request timeout on default HTTP client

### DIFF
--- a/cmd_selfupdate.go
+++ b/cmd_selfupdate.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/jskoll/wyrm/internal/selfupdate"
 )
@@ -32,7 +33,9 @@ func (a *app) selfupdate(args []string) error {
 
 	client := a.httpClient
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{
+			Timeout: 30 * time.Second,
+		}
 	}
 
 	rel, err := fetchRelease(client, *pin)

--- a/cmd_selfupdate_test.go
+++ b/cmd_selfupdate_test.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jskoll/wyrm/internal/selfupdate"
 )
@@ -176,6 +177,23 @@ func TestSelfupdateRejectsPositionalArgs(t *testing.T) {
 	a := &app{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
 	if err := a.selfupdate([]string{"extra"}); err == nil {
 		t.Fatal("selfupdate: want error for unexpected positional argument, got nil")
+	}
+}
+
+func TestSelfupdateTimesOut(t *testing.T) {
+	// A server that hangs without responding
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{
+		Transport: rewriteTransport{addr: srv.Listener.Addr().String()},
+		Timeout:   50 * time.Millisecond,
+	}
+	a := &app{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}, httpClient: client}
+	if err := a.selfupdate([]string{"-check"}); err == nil {
+		t.Fatal("selfupdate: want error on stalled/timed out request, got nil")
 	}
 }
 


### PR DESCRIPTION
### Summary
This PR addresses [SEC-12] (Issue #20) by replacing the unbounded `http.DefaultClient` (which has a timeout of 0) in `wyrm selfupdate` with an `*http.Client` configured with a 30-second request timeout.

### Changes
- Updated `cmd_selfupdate.go` to initialize an `http.Client` with `Timeout: 30 * time.Second` when no client is explicitly injected.
- Added `TestSelfupdateTimesOut` in `cmd_selfupdate_test.go` verifying that stalled network requests abort cleanly and return an error.

Fixes #20