### PR TITLE
feat(config): add wyrm init configuration wizard and starter templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `wyrm init` interactive configuration wizard and starter templates (`node`, `python`, `go`, `rust`, `monorepo`, `minimal`). Supports `--template` / `-t`, `--force` / `-f`, and `--config` flags.
+
 ## [1.0.0] - 2026-08-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Docs site (mkdocs material, published to GitHub Pages): `make docs-install`,
 policy. Verb implementations live in `cmd_*.go` grouped by what they act on:
 
 - `cmd_session.go` — `up`, `restart`, `kill`, attach-by-name
-- `cmd_config.go` — `edit`, `validate`, `save`, `migrate-config`, `list-configs`
+- `cmd_config.go` — `edit`, `validate`, `save`, `migrate-config`, `list-configs`, `init`
 - `cmd_ui.go` — `pick`, `tui`, `list`
 
 `run` takes stdio, a `tmux.Runner`, `insideTmux`, and `attach` as parameters, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ The integration tests run a real tmux server on an isolated socket
 ```
 main.go            subcommand dispatch, error/exit-code policy, shared helpers
 cmd_session.go     up, restart, kill, attach-by-name
-cmd_config.go      edit, validate, save, migrate-config, list-configs
+cmd_config.go      edit, validate, save, migrate-config, list-configs, init
 cmd_ui.go          pick, tui, list
 internal/config/   TOML types, parsing, validation, settings, project discovery
 internal/tmux/     Runner interface, real exec implementation, dry-run recorder

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ wyrm validate               # check the effective config parses and validates (-
 wyrm list                   # list running tmux sessions non-interactively
 wyrm list-configs           # list candidate config file paths (used by shell completion)
 wyrm migrate-config         # move the local config into the shared config directory
+wyrm init                   # scaffold a project config interactively or with -template (-force)
 wyrm clone REPO [DEST]      # git clone, then build (and attach to) a session for it
 wyrm selfupdate             # download and install the latest release (-check, -version V)
 wyrm version                # print version
@@ -524,9 +525,20 @@ Colors are literal hex rather than terminal palette indices, so a theme looks
 the same wherever it runs; Lipgloss degrades them on terminals without true
 color and drops them entirely under [`NO_COLOR`](https://no-color.org).
 
-`wyrm tui` and `wyrm pick` are the same [Charm](https://charm.sh) stack
-program (Bubble Tea / Lipgloss); the core build/attach path stays free of it,
-so `wyrm up` never renders anything.
+## Initializing a new configuration
+
+`wyrm init` scaffolds a well-commented `.wyrm.toml` config, either interactively via a step-by-step wizard or from a starter template:
+
+```sh
+wyrm init                       # interactive wizard (session name, root, layout presets, commands)
+wyrm init -template go          # non-interactively scaffold a Go starter template
+wyrm init -template node        # Node.js template
+wyrm init -template python      # Python template
+wyrm init -template rust        # Rust template
+wyrm init -template monorepo    # Monorepo template
+wyrm init -template minimal     # Minimal 2-pane template
+wyrm init -force                # overwrite an existing config without confirmation
+```
 
 ## Saving a running session
 

--- a/cmd_config.go
+++ b/cmd_config.go
@@ -1,14 +1,17 @@
 package main
 
 // Verbs that act on config files rather than on running sessions: edit,
-// validate, save, migrate-config, list-configs.
+// validate, save, migrate-config, list-configs, init.
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/jskoll/wyrm/internal/config"
 	"github.com/jskoll/wyrm/internal/editor"
@@ -325,4 +328,302 @@ func (a *app) saveRoot(sessionID, dest string) string {
 		"wyrm: warning: the session's directory (%s) is not where this config is being written (%s); saving an absolute session.root\n",
 		path, destDir)
 	return path
+}
+
+// init scaffolds a project configuration either interactively through a
+// guided CLI wizard or non-interactively using a starter template (-template).
+func (a *app) init(args []string) error {
+	fs := a.newFlagSet("init")
+	var templateFlag, templateFlagShort string
+	var forceFlag, forceFlagShort bool
+	var configPath string
+
+	fs.StringVar(&templateFlag, "template", "", "starter template (node, python, go, rust, monorepo, minimal)")
+	fs.StringVar(&templateFlagShort, "t", "", "alias for -template")
+	fs.BoolVar(&forceFlag, "force", false, "overwrite existing config without prompting")
+	fs.BoolVar(&forceFlagShort, "f", false, "alias for -force")
+	fs.StringVar(&configPath, "config", "", "path to write config file (default: .wyrm.toml)")
+
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if err := requireNoArgs(fs); err != nil {
+		return err
+	}
+
+	templateName := templateFlag
+	if templateName == "" {
+		templateName = templateFlagShort
+	}
+	force := forceFlag || forceFlagShort
+
+	settings, err := config.LoadSettings()
+	if err != nil {
+		return err
+	}
+
+	dest, exists, err := a.initDestination(settings, configPath)
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(a.in())
+
+	if exists && !force {
+		_, _ = fmt.Fprintf(a.stdout, "%s already exists. Overwrite? [y/N]: ", dest)
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return readErr
+		}
+		ans := strings.TrimSpace(strings.ToLower(line))
+		if ans != "y" && ans != "yes" {
+			return fmt.Errorf("%s already exists, use --force to overwrite", dest)
+		}
+	}
+
+	cwd, _ := os.Getwd()
+	defaultName := filepath.Base(cwd)
+	if defaultName == "" || defaultName == "." || defaultName == "/" {
+		defaultName = "myproject"
+	}
+
+	var content string
+	if templateName != "" {
+		content, err = config.GetTemplate(templateName, defaultName, ".")
+		if err != nil {
+			return usageErrf("%v", err)
+		}
+	} else {
+		content, err = a.runInitWizard(reader, defaultName)
+		if err != nil {
+			return err
+		}
+	}
+
+	data := []byte(content)
+	cfg, unknown, err := config.Decode(data)
+	if err != nil {
+		return fmt.Errorf("generating config: %w", err)
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("generating config: unknown keys %v", unknown)
+	}
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("validating config: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+
+	if err := state.AtomicWriteFile(dest, data, 0o644); err != nil {
+		return err
+	}
+
+	a.printWarnings(cfg)
+	_, _ = fmt.Fprintf(a.stdout, "wrote %s\n", dest)
+	return nil
+}
+
+func (a *app) initDestination(settings *config.Settings, explicit string) (string, bool, error) {
+	if explicit != "" {
+		if _, err := os.Stat(explicit); err == nil {
+			return explicit, true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", false, err
+		}
+		return explicit, false, nil
+	}
+
+	dest, exists, err := config.EditTarget(settings)
+	if err != nil {
+		return "", false, err
+	}
+	return dest, exists, nil
+}
+
+func (a *app) runInitWizard(reader *bufio.Reader, defaultSessionName string) (string, error) {
+	sessionName, err := promptLine(reader, a.stdout, "Session name", defaultSessionName)
+	if err != nil {
+		return "", err
+	}
+	if sessionName == "" {
+		sessionName = defaultSessionName
+	}
+
+	sessionRoot, err := promptLine(reader, a.stdout, "Root directory", ".")
+	if err != nil {
+		return "", err
+	}
+	if sessionRoot == "" {
+		sessionRoot = "."
+	}
+
+	_, _ = fmt.Fprintln(a.stdout, "\nChoose configuration method:")
+	_, _ = fmt.Fprintln(a.stdout, "  1) Custom layout (interactive wizard)")
+	_, _ = fmt.Fprintln(a.stdout, "  2) Node.js (dev server + test watch)")
+	_, _ = fmt.Fprintln(a.stdout, "  3) Python (editor + pytest + repl)")
+	_, _ = fmt.Fprintln(a.stdout, "  4) Go (editor + test watch + server)")
+	_, _ = fmt.Fprintln(a.stdout, "  5) Rust (editor + test + check + run)")
+	_, _ = fmt.Fprintln(a.stdout, "  6) Monorepo (services + packages + git)")
+	_, _ = fmt.Fprintln(a.stdout, "  7) Minimal (editor + shell)")
+
+	choice, err := promptLine(reader, a.stdout, "Select [1-7]", "1")
+	if err != nil {
+		return "", err
+	}
+
+	switch strings.TrimSpace(choice) {
+	case "2", "node", "nodejs":
+		return config.GetTemplate("node", sessionName, sessionRoot)
+	case "3", "python", "py":
+		return config.GetTemplate("python", sessionName, sessionRoot)
+	case "4", "go", "golang":
+		return config.GetTemplate("go", sessionName, sessionRoot)
+	case "5", "rust", "rs":
+		return config.GetTemplate("rust", sessionName, sessionRoot)
+	case "6", "monorepo":
+		return config.GetTemplate("monorepo", sessionName, sessionRoot)
+	case "7", "minimal":
+		return config.GetTemplate("minimal", sessionName, sessionRoot)
+	default:
+		// Custom layout wizard
+	}
+
+	var windows []config.WindowSpec
+	winIdx := 1
+	for {
+		defaultWinName := "main"
+		if winIdx > 1 {
+			defaultWinName = fmt.Sprintf("window%d", winIdx)
+		}
+
+		_, _ = fmt.Fprintf(a.stdout, "\n--- Window %d ---\n", winIdx)
+		winName, err := promptLine(reader, a.stdout, "Window name", defaultWinName)
+		if err != nil {
+			return "", err
+		}
+		if winName == "" {
+			winName = defaultWinName
+		}
+
+		_, _ = fmt.Fprintln(a.stdout, "Layout presets:")
+		_, _ = fmt.Fprintln(a.stdout, "  1) Single pane")
+		_, _ = fmt.Fprintln(a.stdout, "  2) 2-pane vertical split (left / right)")
+		_, _ = fmt.Fprintln(a.stdout, "  3) 2-pane horizontal split (top / bottom)")
+		_, _ = fmt.Fprintln(a.stdout, "  4) 3-pane (editor left, 2 stacked right)")
+		_, _ = fmt.Fprintln(a.stdout, "  5) 3-pane main horizontal (top / 2 bottom)")
+
+		layoutChoice, err := promptLine(reader, a.stdout, "Select layout [1-5]", "2")
+		if err != nil {
+			return "", err
+		}
+
+		preset := config.PresetTwoPaneVertical
+		switch strings.TrimSpace(layoutChoice) {
+		case "1":
+			preset = config.PresetSingle
+		case "2":
+			preset = config.PresetTwoPaneVertical
+		case "3":
+			preset = config.PresetTwoPaneHorizontal
+		case "4":
+			preset = config.PresetThreePaneEditorStack
+		case "5":
+			preset = config.PresetThreePaneMainHorizontal
+		}
+
+		var commands []string
+		switch preset {
+		case config.PresetSingle:
+			cmd1, err := promptLine(reader, a.stdout, "Command (leave empty for shell)", "$EDITOR .")
+			if err != nil {
+				return "", err
+			}
+			commands = append(commands, cmd1)
+		case config.PresetTwoPaneVertical:
+			cmd1, err := promptLine(reader, a.stdout, "Left pane command", "$EDITOR .")
+			if err != nil {
+				return "", err
+			}
+			cmd2, err := promptLine(reader, a.stdout, "Right pane command (leave empty for shell)", "")
+			if err != nil {
+				return "", err
+			}
+			commands = append(commands, cmd1, cmd2)
+		case config.PresetTwoPaneHorizontal:
+			cmd1, err := promptLine(reader, a.stdout, "Top pane command", "$EDITOR .")
+			if err != nil {
+				return "", err
+			}
+			cmd2, err := promptLine(reader, a.stdout, "Bottom pane command (leave empty for shell)", "")
+			if err != nil {
+				return "", err
+			}
+			commands = append(commands, cmd1, cmd2)
+		case config.PresetThreePaneEditorStack:
+			cmd1, err := promptLine(reader, a.stdout, "Main/editor pane command", "$EDITOR .")
+			if err != nil {
+				return "", err
+			}
+			cmd2, err := promptLine(reader, a.stdout, "Top-right pane command (leave empty for shell)", "")
+			if err != nil {
+				return "", err
+			}
+			cmd3, err := promptLine(reader, a.stdout, "Bottom-right pane command (leave empty for shell)", "")
+			if err != nil {
+				return "", err
+			}
+			commands = append(commands, cmd1, cmd2, cmd3)
+		case config.PresetThreePaneMainHorizontal:
+			cmd1, err := promptLine(reader, a.stdout, "Top/main pane command", "$EDITOR .")
+			if err != nil {
+				return "", err
+			}
+			cmd2, err := promptLine(reader, a.stdout, "Bottom-left pane command (leave empty for shell)", "")
+			if err != nil {
+				return "", err
+			}
+			cmd3, err := promptLine(reader, a.stdout, "Bottom-right pane command (leave empty for shell)", "")
+			if err != nil {
+				return "", err
+			}
+			commands = append(commands, cmd1, cmd2, cmd3)
+		}
+
+		windows = append(windows, config.WindowSpec{
+			Name:     winName,
+			Preset:   preset,
+			Commands: commands,
+		})
+
+		more, err := promptLine(reader, a.stdout, "Add another window? [y/N]", "N")
+		if err != nil {
+			return "", err
+		}
+		ans := strings.TrimSpace(strings.ToLower(more))
+		if ans != "y" && ans != "yes" {
+			break
+		}
+		winIdx++
+	}
+
+	return config.GenerateCustomConfig(sessionName, sessionRoot, windows), nil
+}
+
+func promptLine(reader *bufio.Reader, w io.Writer, prompt string, defaultVal string) (string, error) {
+	if defaultVal != "" {
+		_, _ = fmt.Fprintf(w, "%s [%s]: ", prompt, defaultVal)
+	} else {
+		_, _ = fmt.Fprintf(w, "%s: ", prompt)
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return defaultVal, nil
+	}
+	return line, nil
 }

--- a/cmd_init_test.go
+++ b/cmd_init_test.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jskoll/wyrm/internal/config"
+)
+
+func TestInitTemplateNonInteractive(t *testing.T) {
+	templates := []struct {
+		flagName string
+		wantCmd  string
+	}{
+		{"node", "npm run dev"},
+		{"nodejs", "npm run dev"},
+		{"python", "pytest -v --tb=short"},
+		{"py", "pytest -v --tb=short"},
+		{"go", "go test -v ./..."},
+		{"golang", "go test -v ./..."},
+		{"rust", "cargo test"},
+		{"rs", "cargo test"},
+		{"monorepo", "services"},
+		{"minimal", "main"},
+	}
+
+	for _, tc := range templates {
+		t.Run(tc.flagName, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+
+			var stdout, stderr bytes.Buffer
+			app := &app{
+				stdout: &stdout,
+				stderr: &stderr,
+			}
+
+			if err := app.init([]string{"-template", tc.flagName}); err != nil {
+				t.Fatalf("init -template %s failed: %v", tc.flagName, err)
+			}
+
+			cfgPath := filepath.Join(dir, config.DefaultFileName)
+			cfg, err := config.Load(cfgPath)
+			if err != nil {
+				t.Fatalf("Load(%s) failed: %v", cfgPath, err)
+			}
+
+			if len(cfg.Warnings()) > 0 {
+				t.Errorf("unexpected warnings: %v", cfg.Warnings())
+			}
+
+			content, err := os.ReadFile(cfgPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(content), tc.wantCmd) {
+				t.Errorf("expected config to contain %q, got:\n%s", tc.wantCmd, string(content))
+			}
+
+			if !strings.Contains(stdout.String(), "wrote .wyrm.toml") {
+				t.Errorf("expected stdout to mention wrote .wyrm.toml, got %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestInitUnknownTemplate(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	var stdout, stderr bytes.Buffer
+	app := &app{
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	err := app.init([]string{"-template", "invalid-template"})
+	if err == nil {
+		t.Fatal("expected error for unknown template, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "unknown template") {
+		t.Errorf("expected error message to mention unknown template, got %v", err)
+	}
+}
+
+func TestInitInteractiveDefaults(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	var stdout, stderr bytes.Buffer
+	// Empty stdin will hit EOF and use all default choices
+	app := &app{
+		stdin:  strings.NewReader("\n\n\n\n\n\n\n\n"),
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	if err := app.init(nil); err != nil {
+		t.Fatalf("interactive init failed: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, config.DefaultFileName)
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%s) failed: %v", cfgPath, err)
+	}
+
+	if len(cfg.Windows) != 1 {
+		t.Fatalf("expected 1 window, got %d", len(cfg.Windows))
+	}
+	if cfg.Windows[0].Name != "main" {
+		t.Errorf("expected window name 'main', got %q", cfg.Windows[0].Name)
+	}
+	if len(cfg.Windows[0].Splits) != 2 {
+		t.Fatalf("expected 2 splits for default 2-pane vertical, got %d", len(cfg.Windows[0].Splits))
+	}
+}
+
+func TestInitInteractiveCustomWizard(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Prompts in order:
+	// 1. Session name: "custom-sess"
+	// 2. Root directory: "."
+	// 3. Method: "1" (custom layout)
+	// 4. Window 1 name: "dev"
+	// 5. Window 1 layout: "4" (3-pane editor stack)
+	// 6. Main command: "nvim"
+	// 7. Top-right command: "npm run watch"
+	// 8. Bottom-right command: "npm test"
+	// 9. Add another window?: "y"
+	// 10. Window 2 name: "db"
+	// 11. Window 2 layout: "1" (single pane)
+	// 12. Window 2 command: "psql"
+	// 13. Add another window?: "n"
+	input := strings.Join([]string{
+		"custom-sess",
+		".",
+		"1",
+		"dev",
+		"4",
+		"nvim",
+		"npm run watch",
+		"npm test",
+		"y",
+		"db",
+		"1",
+		"psql",
+		"n",
+	}, "\n") + "\n"
+
+	var stdout, stderr bytes.Buffer
+	app := &app{
+		stdin:  strings.NewReader(input),
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	if err := app.init(nil); err != nil {
+		t.Fatalf("interactive custom init failed: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, config.DefaultFileName)
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%s) failed: %v", cfgPath, err)
+	}
+
+	if cfg.Session.Name != "custom-sess" {
+		t.Errorf("expected session name 'custom-sess', got %q", cfg.Session.Name)
+	}
+	if len(cfg.Windows) != 2 {
+		t.Fatalf("expected 2 windows, got %d", len(cfg.Windows))
+	}
+	if cfg.Windows[0].Name != "dev" {
+		t.Errorf("expected window 0 name 'dev', got %q", cfg.Windows[0].Name)
+	}
+	if cfg.Windows[1].Name != "db" {
+		t.Errorf("expected window 1 name 'db', got %q", cfg.Windows[1].Name)
+	}
+}
+
+func TestInitInteractiveSelectTemplate(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Prompts:
+	// 1. Session name: "my-go-app"
+	// 2. Root directory: "."
+	// 3. Method: "4" (Go)
+	input := strings.Join([]string{
+		"my-go-app",
+		".",
+		"4",
+	}, "\n") + "\n"
+
+	var stdout, stderr bytes.Buffer
+	app := &app{
+		stdin:  strings.NewReader(input),
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	if err := app.init(nil); err != nil {
+		t.Fatalf("interactive template select failed: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, config.DefaultFileName)
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%s) failed: %v", cfgPath, err)
+	}
+
+	if cfg.Session.Name != "my-go-app" {
+		t.Errorf("expected session name 'my-go-app', got %q", cfg.Session.Name)
+	}
+}
+
+func TestInitExistingConfigPromptNo(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cfgPath := filepath.Join(dir, config.DefaultFileName)
+	sentinel := "# Original Config"
+	if err := os.WriteFile(cfgPath, []byte(sentinel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := &app{
+		stdin:  strings.NewReader("n\n"),
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	err := app.init([]string{"-template", "go"})
+	if err == nil {
+		t.Fatal("expected error when user says no to overwrite, got nil")
+	}
+
+	content, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != sentinel {
+		t.Errorf("expected original content to be preserved, got %q", string(content))
+	}
+}
+
+func TestInitExistingConfigPromptYes(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cfgPath := filepath.Join(dir, config.DefaultFileName)
+	sentinel := "# Original Config"
+	if err := os.WriteFile(cfgPath, []byte(sentinel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := &app{
+		stdin:  strings.NewReader("yes\n"),
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	if err := app.init([]string{"-template", "go"}); err != nil {
+		t.Fatalf("init failed after confirming overwrite: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%s) failed: %v", cfgPath, err)
+	}
+	if len(cfg.Windows) == 0 {
+		t.Errorf("expected windows in overwritten config")
+	}
+}
+
+func TestInitExistingConfigForce(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cfgPath := filepath.Join(dir, config.DefaultFileName)
+	sentinel := "# Original Config"
+	if err := os.WriteFile(cfgPath, []byte(sentinel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := &app{
+		stdin:  strings.NewReader(""), // No input needed because of --force
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	if err := app.init([]string{"-template", "rust", "-force"}); err != nil {
+		t.Fatalf("init with -force failed: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%s) failed: %v", cfgPath, err)
+	}
+	if len(cfg.Windows) == 0 {
+		t.Errorf("expected windows in overwritten config")
+	}
+}
+
+func TestInitExplicitConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	customPath := filepath.Join(dir, "nested", "custom.wyrm.toml")
+
+	var stdout, stderr bytes.Buffer
+	app := &app{
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	if err := app.init([]string{"-config", customPath, "-template", "python"}); err != nil {
+		t.Fatalf("init -config failed: %v", err)
+	}
+
+	cfg, err := config.Load(customPath)
+	if err != nil {
+		t.Fatalf("Load(%s) failed: %v", customPath, err)
+	}
+	if len(cfg.Windows) == 0 {
+		t.Errorf("expected windows in custom config")
+	}
+}
+
+func TestInitExtraArgsRejected(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := &app{
+		stdout: &stdout,
+		stderr: &stderr,
+	}
+
+	err := app.init([]string{"stray-argument"})
+	if err == nil {
+		t.Fatal("expected error on unexpected argument, got nil")
+	}
+}

--- a/completions/_wyrm
+++ b/completions/_wyrm
@@ -30,6 +30,7 @@ _wyrm() {
         'list-configs:list candidate config file paths'
         'migrate-config:move the local config into the shared config directory'
         'clone:git clone, then build and attach a session'
+        'init:scaffold a project config interactively or from a template'
         'selfupdate:download and install the latest release'
         'version:print version and exit'
         'help:show help'
@@ -48,8 +49,15 @@ _wyrm() {
             ;;
         args)
             case "$words[1]" in
-                up|restart|kill|edit|validate)
+                up|restart|kill|edit|validate|save)
                     _arguments '-config[config file path]:config file:->configs'
+                    ;;
+                init)
+                    _arguments '-config[config file path]:config file:->configs' \
+                        '-template[starter template]:template:(node python go rust monorepo minimal)' \
+                        '-t[starter template]:template:(node python go rust monorepo minimal)' \
+                        '-force[overwrite existing config without prompting]' \
+                        '-f[overwrite existing config without prompting]'
                     ;;
                 status)
                     _arguments '-format[output format]:format:(text json tmux waybar sketchybar)' \

--- a/completions/wyrm.bash
+++ b/completions/wyrm.bash
@@ -29,9 +29,13 @@ _wyrm_complete() {
             COMPREPLY=($(compgen -W "table json toml names" -- "$cur"))
             return
             ;;
+        -template|-t)
+            COMPREPLY=($(compgen -W "node python go rust monorepo minimal" -- "$cur"))
+            return
+            ;;
     esac
 
-    local subcommands="up restart kill pick tui save edit validate status list list-configs migrate-config clone selfupdate version help"
+    local subcommands="up restart kill pick tui save edit validate status list list-configs migrate-config clone selfupdate version help init"
 
     # First token: a subcommand, or a running session name to attach to.
     if [[ "$COMP_CWORD" -eq 1 ]]; then
@@ -46,7 +50,8 @@ _wyrm_complete() {
     # Subcommand-specific flags.
     if [[ "$cur" == -* ]]; then
         case "$cmd" in
-            up|restart|kill|edit|validate) COMPREPLY=($(compgen -W "-config" -- "$cur")) ;;
+            up|restart|kill|edit|validate|save) COMPREPLY=($(compgen -W "-config" -- "$cur")) ;;
+            init) COMPREPLY=($(compgen -W "-config -template -t -force -f" -- "$cur")) ;;
             status) COMPREPLY=($(compgen -W "-format -session -v" -- "$cur")) ;;
             list) COMPREPLY=($(compgen -W "-format" -- "$cur")) ;;
             selfupdate) COMPREPLY=($(compgen -W "-check -version" -- "$cur")) ;;

--- a/completions/wyrm.fish
+++ b/completions/wyrm.fish
@@ -15,7 +15,7 @@
 # not "--config"), hence "-o" (old-style option) below rather than fish's
 # usual "-l" (GNU-style long option).
 
-set -l subcommands up restart kill pick tui save edit validate status list list-configs migrate-config clone selfupdate version help
+set -l subcommands up restart kill pick tui save edit validate status list list-configs migrate-config clone selfupdate version help init
 
 # Don't fall back to filename completion.
 complete -c wyrm -f
@@ -34,6 +34,7 @@ complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a list -d 'l
 complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a list-configs -d 'list candidate config file paths'
 complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a migrate-config -d 'move the local config into the shared dir'
 complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a clone -d 'git clone, then build and attach a session'
+complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a init -d 'scaffold a new config interactively or from a template'
 complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a selfupdate -d 'download and install the latest release'
 complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a version -d 'print version and exit'
 complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a help -d 'show help'
@@ -41,7 +42,12 @@ complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a help -d 's
 complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a '(wyrm list -format names 2>/dev/null)' -d 'running session'
 
 # Subcommand flags.
-complete -c wyrm -n '__fish_seen_subcommand_from up restart kill edit validate' -o config -d 'config file path' -r -a '(wyrm list-configs 2>/dev/null)'
+complete -c wyrm -n '__fish_seen_subcommand_from up restart kill edit validate save' -o config -d 'config file path' -r -a '(wyrm list-configs 2>/dev/null)'
+complete -c wyrm -n '__fish_seen_subcommand_from init' -o config -d 'config file path' -r -a '(wyrm list-configs 2>/dev/null)'
+complete -c wyrm -n '__fish_seen_subcommand_from init' -o template -d 'starter template' -x -a 'node python go rust monorepo minimal'
+complete -c wyrm -n '__fish_seen_subcommand_from init' -o t -d 'starter template' -x -a 'node python go rust monorepo minimal'
+complete -c wyrm -n '__fish_seen_subcommand_from init' -o force -d 'overwrite existing config without prompting'
+complete -c wyrm -n '__fish_seen_subcommand_from init' -o f -d 'overwrite existing config without prompting'
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o format -d 'output format' -x -a 'text json tmux waybar sketchybar'
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o session -d 'filter to session' -x
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o v -d 'verbose output'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,21 @@ directory's basename) inside `shared_dir` first, falling back to the normal
 local search if it's missing. Run `wyrm migrate-config` to move an existing
 local config into the shared directory under the right name.
 
+## Creating a config (`wyrm init`)
+
+Run `wyrm init` to generate a new `.wyrm.toml` for the current project. By default it guides you through an interactive wizard (session name, root directory, window layout presets, and pane commands), or you can scaffold starter templates non-interactively:
+
+```sh
+wyrm init                       # interactive wizard
+wyrm init -template go          # Go template
+wyrm init -template node        # Node.js template
+wyrm init -template python      # Python template
+wyrm init -template rust        # Rust template
+wyrm init -template monorepo    # Monorepo template
+wyrm init -template minimal     # Minimal 2-pane template
+wyrm init -force                # overwrite an existing config without confirmation
+```
+
 ## `[[wildcard]]` — one config, many directories
 
 A `[[wildcard]]` entry applies one template config to every directory

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ The integration tests run a real tmux server on an isolated socket
 ```
 main.go            subcommand dispatch, error/exit-code policy, shared helpers
 cmd_session.go     up, restart, kill, attach-by-name
-cmd_config.go      edit, validate, save, migrate-config, list-configs
+cmd_config.go      edit, validate, save, migrate-config, list-configs, init
 cmd_ui.go          pick, tui, list
 internal/config/   TOML types, parsing, validation, settings, project discovery
 internal/tmux/     Runner interface, real exec implementation, dry-run recorder

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ wyrm validate             # check the effective config parses and validates (-st
 wyrm list                 # list running tmux sessions non-interactively
 wyrm list-configs         # list candidate config file paths (used by shell completion)
 wyrm migrate-config       # move the local config into the shared config directory
+wyrm init                 # scaffold a project config interactively or with -template (-force)
 wyrm clone REPO [DEST]    # git clone, then build (and attach to) a session for it (-no-start to skip)
 wyrm selfupdate           # download and install the latest release
 wyrm version
@@ -314,6 +315,21 @@ color and drops them entirely under [`NO_COLOR`](https://no-color.org).
 `wyrm tui` and `wyrm pick` are the same [Charm](https://charm.sh) stack
 program (Bubble Tea / Lipgloss); the core build/attach path stays free of it,
 so `wyrm up` never renders anything.
+
+## Initializing a new configuration
+
+`wyrm init` scaffolds a well-commented `.wyrm.toml` config, either interactively via a step-by-step wizard or from a starter template:
+
+```sh
+wyrm init                       # interactive wizard (session name, root, layout presets, commands)
+wyrm init -template go          # non-interactively scaffold a Go starter template
+wyrm init -template node        # Node.js template
+wyrm init -template python      # Python template
+wyrm init -template rust        # Rust template
+wyrm init -template monorepo    # Monorepo template
+wyrm init -template minimal     # Minimal 2-pane template
+wyrm init -force                # overwrite an existing config without confirmation
+```
 
 ## Saving a running session
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,7 +195,7 @@ func Load(path string) (*Config, error) {
 	return cfg, nil
 }
 
-// decode parses TOML into a Config and reports any keys the file sets that
+// Decode parses TOML into a Config and reports any keys the file sets that
 // Config has no field for.
 //
 // Unknown keys are collected rather than rejected. A misspelled key is silently
@@ -207,6 +207,10 @@ func Load(path string) (*Config, error) {
 //
 // go-toml still fills the destination when it reports strict errors, so the
 // returned Config is complete either way.
+func Decode(data []byte) (*Config, []string, error) {
+	return decode(data)
+}
+
 func decode(data []byte) (*Config, []string, error) {
 	var cfg Config
 	dec := toml.NewDecoder(bytes.NewReader(data))
@@ -248,6 +252,11 @@ func LoadDefault() (*Config, error) {
 		return nil, fmt.Errorf("default config: %w", err)
 	}
 	return cfg, nil
+}
+
+// Validate checks that the config has a valid session and window structure.
+func (c *Config) Validate() error {
+	return c.validate()
 }
 
 func (c *Config) validate() error {

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -1,0 +1,438 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Layout preset constants for interactive scaffolding.
+const (
+	PresetSingle                  = 1
+	PresetTwoPaneVertical         = 2
+	PresetTwoPaneHorizontal       = 3
+	PresetThreePaneEditorStack    = 4
+	PresetThreePaneMainHorizontal = 5
+)
+
+// WindowSpec describes a window to generate in a custom config.
+type WindowSpec struct {
+	Name     string
+	Preset   int
+	Commands []string
+}
+
+// TemplateDef describes a starter template and its aliases.
+type TemplateDef struct {
+	Name        string
+	Aliases     []string
+	Description string
+	Template    string
+}
+
+var starterTemplates = []TemplateDef{
+	{
+		Name:        "node",
+		Aliases:     []string{"nodejs", "javascript", "js", "ts", "typescript"},
+		Description: "Node.js project (dev server + test watch)",
+		Template: `# Node.js project configuration
+# Run 'wyrm' to start this session.
+
+[session]
+name = %s
+root = %s
+
+[[windows]]
+name = "dev"
+
+  [[windows.splits]]
+  command = "$EDITOR ."
+
+  [[windows.splits]]
+  type = "h"          # split right: watcher gets 35%% width
+  size = 35
+  command = "npm run dev"
+
+[[windows]]
+name = "test"
+
+  [[windows.splits]]
+  command = "npm test -- --watch"
+
+  [[windows.splits]]
+  type = "v"          # split below: 50%% height
+  size = 50
+  command = "# test logs / terminal"
+`,
+	},
+	{
+		Name:        "python",
+		Aliases:     []string{"py"},
+		Description: "Python project (editor + pytest + repl)",
+		Template: `# Python project configuration
+# Run 'wyrm' to start this session.
+
+[session]
+name = %s
+root = %s
+
+[[windows]]
+name = "editor"
+
+  [[windows.splits]]
+  command = "$EDITOR ."
+
+  [[windows.splits]]
+  type = "h"          # split right: 30%% width
+  size = 30
+  command = "# venv: source .venv/bin/activate"
+
+[[windows]]
+name = "test"
+
+  [[windows.splits]]
+  command = "pytest -v --tb=short"
+
+  [[windows.splits]]
+  type = "v"          # split below: 50%% height
+  size = 50
+  command = "# coverage / lint"
+
+[[windows]]
+name = "repl"
+
+  [[windows.splits]]
+  command = "python"
+`,
+	},
+	{
+		Name:        "go",
+		Aliases:     []string{"golang"},
+		Description: "Go project (editor + test watch + server)",
+		Template: `# Go project configuration
+# Run 'wyrm' to start this session.
+
+[session]
+name = %s
+root = %s
+
+[[windows]]
+name = "code"
+
+  [[windows.splits]]
+  command = "$EDITOR ."
+
+  [[windows.splits]]
+  type = "h"          # split right: 35%% width
+  size = 35
+  command = "go test -v ./..."
+
+    [[windows.splits.children]]
+    type = "v"        # split below: 50%% height
+    size = 50
+    command = "# go run ."
+
+[[windows]]
+name = "server"
+
+  [[windows.splits]]
+  command = "# go run main.go"
+`,
+	},
+	{
+		Name:        "rust",
+		Aliases:     []string{"rs"},
+		Description: "Rust project (editor + test + check + run)",
+		Template: `# Rust project configuration
+# Run 'wyrm' to start this session.
+
+[session]
+name = %s
+root = %s
+
+[[windows]]
+name = "editor"
+
+  [[windows.splits]]
+  command = "$EDITOR ."
+
+  [[windows.splits]]
+  type = "h"          # split right: 35%% width
+  size = 35
+  command = "cargo test"
+
+    [[windows.splits.children]]
+    type = "v"        # split below: 50%% height
+    size = 50
+    command = "cargo check"
+
+[[windows]]
+name = "run"
+
+  [[windows.splits]]
+  command = "cargo run"
+`,
+	},
+	{
+		Name:        "monorepo",
+		Aliases:     []string{"mono", "workspace", "workspaces"},
+		Description: "Monorepo layout (services + packages + git)",
+		Template: `# Monorepo configuration
+# Run 'wyrm' to start this session.
+
+[session]
+name = %s
+root = %s
+
+  # Shared environment variables for all panes
+  # [session.env]
+  # NODE_ENV = "development"
+
+[[windows]]
+name = "services"
+root = "."
+
+  [[windows.splits]]
+  command = "$EDITOR ."
+
+  [[windows.splits]]
+  type = "h"          # split right: 40%% width
+  size = 40
+  command = "# npm run dev / docker compose up"
+
+[[windows]]
+name = "packages"
+root = "."
+
+  [[windows.splits]]
+  command = "# build or watch shared packages"
+
+[[windows]]
+name = "git"
+
+  [[windows.splits]]
+  command = "lazygit"
+`,
+	},
+	{
+		Name:        "minimal",
+		Aliases:     []string{"default", "basic", "simple"},
+		Description: "Minimal 2-pane layout (editor + shell)",
+		Template: `# Minimal project configuration
+# Run 'wyrm' to start this session.
+
+[session]
+name = %s
+root = %s
+
+[[windows]]
+name = "main"
+
+  [[windows.splits]]
+  command = "$EDITOR ."
+
+  [[windows.splits]]
+  type = "h"          # split horizontally: new pane to the right
+  size = 30           # new pane gets 30%% of the width
+`,
+	},
+}
+
+// AvailableTemplates returns the canonical list of available template names.
+func AvailableTemplates() []string {
+	names := make([]string, len(starterTemplates))
+	for i, t := range starterTemplates {
+		names[i] = t.Name
+	}
+	sort.Strings(names)
+	return names
+}
+
+// FindTemplate looks up a starter template by name or alias.
+func FindTemplate(name string) (TemplateDef, bool) {
+	norm := strings.ToLower(strings.TrimSpace(name))
+	for _, t := range starterTemplates {
+		if strings.EqualFold(t.Name, norm) {
+			return t, true
+		}
+		for _, alias := range t.Aliases {
+			if strings.EqualFold(alias, norm) {
+				return t, true
+			}
+		}
+	}
+	return TemplateDef{}, false
+}
+
+// GetTemplate formats a starter template with the given session name and root.
+func GetTemplate(templateName, sessionName, sessionRoot string) (string, error) {
+	tmpl, ok := FindTemplate(templateName)
+	if !ok {
+		return "", fmt.Errorf("unknown template %q (available: %s)", templateName, strings.Join(AvailableTemplates(), ", "))
+	}
+	if sessionName == "" {
+		sessionName = "myproject"
+	}
+	if sessionRoot == "" {
+		sessionRoot = "."
+	}
+	return fmt.Sprintf(tmpl.Template, strconv.Quote(sessionName), strconv.Quote(sessionRoot)), nil
+}
+
+// GenerateCustomConfig formats a custom wyrm configuration from window specifications.
+func GenerateCustomConfig(sessionName, sessionRoot string, windows []WindowSpec) string {
+	if sessionName == "" {
+		sessionName = "myproject"
+	}
+	if sessionRoot == "" {
+		sessionRoot = "."
+	}
+	if len(windows) == 0 {
+		windows = []WindowSpec{
+			{
+				Name:     "main",
+				Preset:   PresetTwoPaneVertical,
+				Commands: []string{"$EDITOR .", ""},
+			},
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# Wyrm session configuration\n")
+	sb.WriteString("# Run 'wyrm' to start this session.\n\n")
+	sb.WriteString("[session]\n")
+	_, _ = fmt.Fprintf(&sb, "name = %s\n", strconv.Quote(sessionName))
+	_, _ = fmt.Fprintf(&sb, "root = %s\n\n", strconv.Quote(sessionRoot))
+	sb.WriteString("# Lifecycle hooks (optional):\n")
+	sb.WriteString("# on_project_start = \"echo 'Starting up...'\"\n")
+	sb.WriteString("# on_project_exit = \"echo 'Cleaning up...'\"\n\n")
+
+	for i, win := range windows {
+		winName := win.Name
+		if winName == "" {
+			if i == 0 {
+				winName = "main"
+			} else {
+				winName = fmt.Sprintf("window%d", i+1)
+			}
+		}
+
+		sb.WriteString("[[windows]]\n")
+		_, _ = fmt.Fprintf(&sb, "name = %s\n\n", strconv.Quote(winName))
+
+		cmdAt := func(idx int) string {
+			if idx < len(win.Commands) {
+				return win.Commands[idx]
+			}
+			return ""
+		}
+
+		switch win.Preset {
+		case PresetSingle:
+			c1 := cmdAt(0)
+			sb.WriteString("  [[windows.splits]]\n")
+			if c1 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c1))
+			} else {
+				sb.WriteString("  # command = \"\"\n\n")
+			}
+
+		case PresetTwoPaneVertical:
+			c1, c2 := cmdAt(0), cmdAt(1)
+			sb.WriteString("  [[windows.splits]]\n")
+			if c1 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c1))
+			} else {
+				sb.WriteString("  # command = \"\"\n\n")
+			}
+			sb.WriteString("  [[windows.splits]]\n")
+			sb.WriteString("  type = \"h\"          # split right: 50% width\n")
+			sb.WriteString("  size = 50\n")
+			if c2 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c2))
+			} else {
+				sb.WriteString("\n")
+			}
+
+		case PresetTwoPaneHorizontal:
+			c1, c2 := cmdAt(0), cmdAt(1)
+			sb.WriteString("  [[windows.splits]]\n")
+			if c1 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c1))
+			} else {
+				sb.WriteString("  # command = \"\"\n\n")
+			}
+			sb.WriteString("  [[windows.splits]]\n")
+			sb.WriteString("  type = \"v\"          # split below: 50% height\n")
+			sb.WriteString("  size = 50\n")
+			if c2 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c2))
+			} else {
+				sb.WriteString("\n")
+			}
+
+		case PresetThreePaneEditorStack:
+			c1, c2, c3 := cmdAt(0), cmdAt(1), cmdAt(2)
+			sb.WriteString("  [[windows.splits]]\n")
+			if c1 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c1))
+			} else {
+				sb.WriteString("  # command = \"\"\n\n")
+			}
+			sb.WriteString("  [[windows.splits]]\n")
+			sb.WriteString("  type = \"h\"          # split right: 35% width\n")
+			sb.WriteString("  size = 35\n")
+			if c2 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c2))
+			} else {
+				sb.WriteString("\n")
+			}
+			sb.WriteString("    [[windows.splits.children]]\n")
+			sb.WriteString("    type = \"v\"        # split below: 50% height\n")
+			sb.WriteString("    size = 50\n")
+			if c3 != "" {
+				_, _ = fmt.Fprintf(&sb, "    command = %s\n\n", strconv.Quote(c3))
+			} else {
+				sb.WriteString("\n")
+			}
+
+		case PresetThreePaneMainHorizontal:
+			c1, c2, c3 := cmdAt(0), cmdAt(1), cmdAt(2)
+			sb.WriteString("  [[windows.splits]]\n")
+			if c1 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c1))
+			} else {
+				sb.WriteString("  # command = \"\"\n\n")
+			}
+			sb.WriteString("  [[windows.splits]]\n")
+			sb.WriteString("  type = \"v\"          # split below: 40% height\n")
+			sb.WriteString("  size = 40\n")
+			if c2 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c2))
+			} else {
+				sb.WriteString("\n")
+			}
+			sb.WriteString("    [[windows.splits.children]]\n")
+			sb.WriteString("    type = \"h\"        # split right: 50% width\n")
+			sb.WriteString("    size = 50\n")
+			if c3 != "" {
+				_, _ = fmt.Fprintf(&sb, "    command = %s\n\n", strconv.Quote(c3))
+			} else {
+				sb.WriteString("\n")
+			}
+
+		default:
+			// Fallback to single pane
+			c1 := cmdAt(0)
+			sb.WriteString("  [[windows.splits]]\n")
+			if c1 != "" {
+				_, _ = fmt.Fprintf(&sb, "  command = %s\n\n", strconv.Quote(c1))
+			} else {
+				sb.WriteString("  # command = \"\"\n\n")
+			}
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n") + "\n"
+}

--- a/internal/config/template_test.go
+++ b/internal/config/template_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestStarterTemplatesValid(t *testing.T) {
+	for _, name := range AvailableTemplates() {
+		t.Run(name, func(t *testing.T) {
+			content, err := GetTemplate(name, "test-session", ".")
+			if err != nil {
+				t.Fatalf("GetTemplate(%q) failed: %v", name, err)
+			}
+			cfg, unknown, err := Decode([]byte(content))
+			if err != nil {
+				t.Fatalf("Decode(%q) failed: %v\nContent:\n%s", name, err, content)
+			}
+			if len(unknown) > 0 {
+				t.Fatalf("Decode(%q) had unknown keys: %v", name, unknown)
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate(%q) failed: %v\nContent:\n%s", name, err, content)
+			}
+			if len(cfg.Warnings()) > 0 {
+				t.Fatalf("Validate(%q) produced warnings: %v", name, cfg.Warnings())
+			}
+			if cfg.Session.Name != "test-session" {
+				t.Errorf("expected session.name %q, got %q", "test-session", cfg.Session.Name)
+			}
+			if cfg.Session.Root != "." {
+				t.Errorf("expected session.root %q, got %q", ".", cfg.Session.Root)
+			}
+			if len(cfg.Windows) == 0 {
+				t.Errorf("expected windows, got 0")
+			}
+		})
+	}
+}
+
+func TestTemplateAliases(t *testing.T) {
+	cases := []struct {
+		alias    string
+		wantName string
+	}{
+		{"nodejs", "node"},
+		{"javascript", "node"},
+		{"js", "node"},
+		{"ts", "node"},
+		{"typescript", "node"},
+		{"py", "python"},
+		{"golang", "go"},
+		{"rs", "rust"},
+		{"mono", "monorepo"},
+		{"workspace", "monorepo"},
+		{"basic", "minimal"},
+		{"default", "minimal"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.alias, func(t *testing.T) {
+			tmpl, ok := FindTemplate(tc.alias)
+			if !ok {
+				t.Fatalf("FindTemplate(%q) returned not found", tc.alias)
+			}
+			if tmpl.Name != tc.wantName {
+				t.Errorf("FindTemplate(%q) = %q, want %q", tc.alias, tmpl.Name, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestGetTemplateUnknown(t *testing.T) {
+	_, err := GetTemplate("nonexistent", "session", ".")
+	if err == nil {
+		t.Fatal("expected error for nonexistent template, got nil")
+	}
+}
+
+func TestGenerateCustomConfigPresets(t *testing.T) {
+	presets := []struct {
+		name     string
+		preset   int
+		commands []string
+	}{
+		{"single", PresetSingle, []string{"nvim"}},
+		{"two-pane-v", PresetTwoPaneVertical, []string{"nvim", "npm test"}},
+		{"two-pane-h", PresetTwoPaneHorizontal, []string{"nvim", "pytest"}},
+		{"three-pane-stack", PresetThreePaneEditorStack, []string{"nvim", "npm run dev", "npm test"}},
+		{"three-pane-main-h", PresetThreePaneMainHorizontal, []string{"nvim", "docker compose up", "cargo test"}},
+	}
+
+	for _, tc := range presets {
+		t.Run(tc.name, func(t *testing.T) {
+			windows := []WindowSpec{
+				{
+					Name:     tc.name,
+					Preset:   tc.preset,
+					Commands: tc.commands,
+				},
+			}
+			content := GenerateCustomConfig("custom-app", "~/code/custom-app", windows)
+			cfg, unknown, err := Decode([]byte(content))
+			if err != nil {
+				t.Fatalf("Decode failed: %v\nContent:\n%s", err, content)
+			}
+			if len(unknown) > 0 {
+				t.Fatalf("Decode had unknown keys: %v", unknown)
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate failed: %v\nContent:\n%s", err, content)
+			}
+			if len(cfg.Warnings()) > 0 {
+				t.Fatalf("Validate produced warnings: %v", cfg.Warnings())
+			}
+			if cfg.Session.Name != "custom-app" {
+				t.Errorf("expected session.name %q, got %q", "custom-app", cfg.Session.Name)
+			}
+			if cfg.Session.Root != "~/code/custom-app" {
+				t.Errorf("expected session.root %q, got %q", "~/code/custom-app", cfg.Session.Root)
+			}
+			if len(cfg.Windows) != 1 {
+				t.Fatalf("expected 1 window, got %d", len(cfg.Windows))
+			}
+		})
+	}
+}
+
+func TestGenerateCustomConfigMultipleWindows(t *testing.T) {
+	windows := []WindowSpec{
+		{
+			Name:     "editor",
+			Preset:   PresetThreePaneEditorStack,
+			Commands: []string{"$EDITOR .", "npm test -- --watch", "npm run dev"},
+		},
+		{
+			Name:     "database",
+			Preset:   PresetTwoPaneHorizontal,
+			Commands: []string{"psql", "redis-cli"},
+		},
+		{
+			Name:     "shell",
+			Preset:   PresetSingle,
+			Commands: []string{""},
+		},
+	}
+	content := GenerateCustomConfig("multi-app", ".", windows)
+	cfg, unknown, err := Decode([]byte(content))
+	if err != nil {
+		t.Fatalf("Decode failed: %v\nContent:\n%s", err, content)
+	}
+	if len(unknown) > 0 {
+		t.Fatalf("Decode had unknown keys: %v", unknown)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v\nContent:\n%s", err, content)
+	}
+	if len(cfg.Warnings()) > 0 {
+		t.Fatalf("Validate produced warnings: %v", cfg.Warnings())
+	}
+	if len(cfg.Windows) != 3 {
+		t.Fatalf("expected 3 windows, got %d", len(cfg.Windows))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func runnerFromSettings(settings *config.Settings) tmux.Exec {
 // what lets each of them return a plain error instead of hand-rolling its own
 // "print wyrm: <err> and return 1" — see run's report.
 type app struct {
+	stdin          io.Reader
 	stdout, stderr io.Writer
 	runner         tmux.Runner
 	insideTmux     func() bool
@@ -61,6 +62,13 @@ type app struct {
 	// construction path below, where it defaults to http.DefaultClient;
 	// tests point it at an httptest server instead.
 	httpClient *http.Client
+}
+
+func (a *app) in() io.Reader {
+	if a.stdin != nil {
+		return a.stdin
+	}
+	return os.Stdin
 }
 
 // exitErr is a subcommand failure carrying an explicit exit status. A nil Err
@@ -162,6 +170,8 @@ func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux
 		return a.report(a.selfupdate(args[1:]))
 	case "status":
 		return a.report(a.status(args[1:]))
+	case "init":
+		return a.report(a.init(args[1:]))
 	default:
 		if strings.HasPrefix(cmd, "-") {
 			// A bare flag with no subcommand (e.g. `wyrm -config x`) drives the
@@ -236,6 +246,7 @@ Usage:
   wyrm list-configs          list candidate config file paths (used by shell completion)
   wyrm migrate-config        move the local config into the shared config directory
   wyrm clone REPO [DEST]     git clone, then build (and attach to) a session for it
+  wyrm init [-template T]    scaffold a project config interactively or with -template (-force)
   wyrm selfupdate            download and install the latest release (-check, -version V)
   wyrm version               print version and exit
   wyrm help                  show this help
@@ -335,7 +346,7 @@ func (a *app) resolveConfig(settings *config.Settings, explicitPath string) (*co
 // power the "did you mean" hint in attachByName.
 var knownSubcommands = []string{
 	"up", "restart", "kill", "pick", "tui", "save", "edit", "validate", "status",
-	"list", "list-configs", "migrate-config", "clone", "selfupdate", "version", "help",
+	"list", "list-configs", "migrate-config", "clone", "selfupdate", "version", "help", "init",
 }
 
 // nearestSubcommand returns the known subcommand closest to name by edit

--- a/man/wyrm.1
+++ b/man/wyrm.1
@@ -93,6 +93,13 @@ config in the shared config directory. Used by shell completion.
 .B wyrm migrate-config
 Move the local config file into the shared config directory.
 .TP
+.BI "wyrm init [\-config " PATH "] [\-template " TEMPLATE "] [\-force]"
+Scaffold a project configuration file. Runs an interactive CLI wizard by default, or non-interactively creates a starter template with
+.B \-template
+(\fBnode\fR, \fBpython\fR, \fBgo\fR, \fBrust\fR, \fBmonorepo\fR, \fBminimal\fR).
+.B \-force
+overwrites an existing config without confirmation.
+.TP
 .BI "wyrm clone " REPO " [" DEST ]
 Run
 .BR "git clone" ,


### PR DESCRIPTION
## Summary
Resolves #37.

Introduces a new subcommand `wyrm init` in `cmd_config.go` providing:
- **Interactive Configuration Wizard**: Prompts for session name (defaulting to current directory basename), root directory (`.`), template selection or custom layout, window names, layout presets, and per-pane startup commands.
- **Starter Templates**: Non-interactive template generation via `--template` / `-t` flag supporting `node`, `python`, `go`, `rust`, `monorepo`, and `minimal` (with common aliases like `nodejs`, `golang`, `py`, `rs`, `ts`, etc.).
- **Overwrite Protection**: Prompts before overwriting an existing `.wyrm.toml` unless `--force` / `-f` is specified.
- **Atomic Writing & Validation**: Validates generated configuration with `config.Decode` and `config.Config.Validate()`, saving atomically via `state.AtomicWriteFile()`.
- **Completions & Documentation**: Shell completions for Bash, Fish, and Zsh, updated man page `wyrm.1`, and documentation site updates.

## Testing
- Added unit and integration test suite in `cmd_init_test.go` and `internal/config/template_test.go`
- `make lint` passed (0 issues)
- `make test-unit`, `make test`, and `make cover` passed (80.6% statement coverage, exceeding the 75% floor)