### PR TITLE
feat(freeze): capture pane working directories during wyrm save and freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Capture pane working directories (`pane_current_path`) during `wyrm save` and `freeze`, preserving relative and absolute directory paths across windows and splits.
+
 ## [1.0.0] - 2026-08-15
 
 ### Added

--- a/internal/freeze/freeze.go
+++ b/internal/freeze/freeze.go
@@ -48,6 +48,31 @@ func paneCommand(commands map[string]string, paneID string) string {
 	return cmd
 }
 
+// relPath returns path relative to baseDir if path is inside baseDir.
+// If path equals baseDir, it returns "".
+// If path is outside baseDir or cannot be resolved relatively, it returns path cleaned.
+func relPath(baseDir, path string) string {
+	if path == "" || baseDir == "" {
+		return ""
+	}
+	base := filepath.Clean(baseDir)
+	target := filepath.Clean(path)
+	if evalBase, err := filepath.EvalSymlinks(base); err == nil {
+		base = evalBase
+	}
+	if evalTarget, err := filepath.EvalSymlinks(target); err == nil {
+		target = evalTarget
+	}
+	if base == target {
+		return ""
+	}
+	rel, err := filepath.Rel(base, target)
+	if err == nil && !strings.HasPrefix(rel, "..") && rel != "." {
+		return filepath.ToSlash(rel)
+	}
+	return target
+}
+
 // Config builds a wyrm config.Config snapshotting the live layout of the
 // tmux session identified by sessionID (a tmux session ID, e.g. "$3").
 // name and root are written into the resulting [session] block as-is.
@@ -60,6 +85,18 @@ func Config(r tmux.Runner, sessionID, name, root string) (*config.Config, error)
 		return nil, fmt.Errorf("session %q has no windows", name)
 	}
 
+	sessionBase := root
+	if sessionBase == "" || sessionBase == "." || !filepath.IsAbs(sessionBase) {
+		if sessionPath, err := tmux.SessionPath(r, sessionID); err == nil && sessionPath != "" {
+			sessionBase = sessionPath
+		} else if cwd, err := os.Getwd(); err == nil {
+			sessionBase = cwd
+		}
+	}
+	if eval, err := filepath.EvalSymlinks(sessionBase); err == nil {
+		sessionBase = eval
+	}
+
 	cfg := &config.Config{
 		Session: config.Session{Name: name, Root: root},
 	}
@@ -70,10 +107,12 @@ func Config(r tmux.Runner, sessionID, name, root string) (*config.Config, error)
 			return nil, fmt.Errorf("window %q: %w", w.Name, err)
 		}
 		commands := make(map[string]string, len(panes))
+		paths := make(map[string]string, len(panes))
 		var activePane int
 		haveActivePane := false
 		for _, p := range panes {
 			commands[p.ID] = p.Command
+			paths[p.ID] = p.Path
 			if p.Active {
 				activePane, haveActivePane = p.Index, true
 			}
@@ -84,9 +123,32 @@ func Config(r tmux.Runner, sessionID, name, root string) (*config.Config, error)
 			return nil, fmt.Errorf("window %q: %w", w.Name, err)
 		}
 
+		var winRoot string
+		if len(panes) > 0 && paths[panes[0].ID] != "" {
+			firstRel := relPath(sessionBase, paths[panes[0].ID])
+			allSame := true
+			for _, p := range panes[1:] {
+				if p.Path == "" || relPath(sessionBase, p.Path) != firstRel {
+					allSame = false
+					break
+				}
+			}
+			if allSame {
+				winRoot = firstRel
+			}
+		}
+
+		effectiveWinBase := sessionBase
+		if winRoot != "" {
+			if wr, err := config.ResolveRoot(sessionBase, winRoot); err == nil {
+				effectiveWinBase = wr
+			}
+		}
+
 		cfg.Windows = append(cfg.Windows, config.Window{
 			Name:   w.Name,
-			Splits: splitsFromNode(layoutRoot, commands),
+			Root:   winRoot,
+			Splits: splitsFromNode(layoutRoot, commands, paths, effectiveWinBase),
 		})
 
 		if w.Active {

--- a/internal/freeze/freeze_test.go
+++ b/internal/freeze/freeze_test.go
@@ -44,12 +44,12 @@ func TestConfigTwoWindows(t *testing.T) {
 			}, "\n"),
 		},
 		panesByWindow: map[string]string{
-			"@1": "%0|0|1|nvim",
-			"@2": "%1|0|0|npm\n%2|1|1|htop",
+			"@1": "%0|0|1|nvim|/path/to/myproj",
+			"@2": "%1|0|0|npm|/path/to/myproj\n%2|1|1|htop|/path/to/myproj",
 		},
 	}
 
-	cfg, err := Config(r, "$3", "myproj", ".")
+	cfg, err := Config(r, "$3", "myproj", "/path/to/myproj")
 	if err != nil {
 		t.Fatalf("Config: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestConfigTwoWindows(t *testing.T) {
 	want := &config.Config{
 		Session: config.Session{
 			Name:          "myproj",
-			Root:          ".",
+			Root:          "/path/to/myproj",
 			StartupWindow: "server",
 			StartupPane:   intPtr(1),
 		},
@@ -67,6 +67,54 @@ func TestConfigTwoWindows(t *testing.T) {
 				{Command: "npm"},
 				{Type: "h", Size: 50, Command: "htop"},
 			}},
+		},
+	}
+	if !reflect.DeepEqual(cfg, want) {
+		t.Errorf("Config() =\n%+v\nwant\n%+v", cfg, want)
+	}
+}
+
+func TestConfigWindowAndSplitRoots(t *testing.T) {
+	r := &fakeRunner{
+		windowsBySession: map[string]string{
+			"$3": strings.Join([]string{
+				"0|@1|0|abcd,139x50,0,0,0|web",
+				"1|@2|1|efgh,139x50,0,0{69x50,0,0,1,69x50,70,0,2}|mixed",
+			}, "\n"),
+		},
+		panesByWindow: map[string]string{
+			"@1": "%0|0|1|npm run dev|/path/to/myproj/frontend",
+			"@2": "%1|0|0|cargo run|/path/to/myproj/backend\n%2|1|1|python run.py|/path/to/myproj/ai",
+		},
+	}
+
+	cfg, err := Config(r, "$3", "myproj", "/path/to/myproj")
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+
+	want := &config.Config{
+		Session: config.Session{
+			Name:          "myproj",
+			Root:          "/path/to/myproj",
+			StartupWindow: "mixed",
+			StartupPane:   intPtr(1),
+		},
+		Windows: []config.Window{
+			{
+				Name: "web",
+				Root: "frontend",
+				Splits: []config.Split{
+					{Command: "npm run dev"},
+				},
+			},
+			{
+				Name: "mixed",
+				Splits: []config.Split{
+					{Command: "cargo run", Root: "backend"},
+					{Type: "h", Size: 50, Command: "python run.py", Root: "ai"},
+				},
+			},
 		},
 	}
 	if !reflect.DeepEqual(cfg, want) {

--- a/internal/freeze/splits.go
+++ b/internal/freeze/splits.go
@@ -20,9 +20,12 @@ import (
 // the percentage handed to cell i-1 out of whatever remained after cells
 // 0..i-2 were carved off, then reduces "remaining" by cell i-1's share
 // before moving on.
-func splitsFromNode(n *layoutNode, commands map[string]string) []config.Split {
+func splitsFromNode(n *layoutNode, commands, paths map[string]string, winBase string) []config.Split {
 	if n.Type == 0 {
-		return []config.Split{{Command: paneCommand(commands, n.PaneID)}}
+		return []config.Split{{
+			Command: paneCommand(commands, n.PaneID),
+			Root:    relPath(winBase, paths[n.PaneID]),
+		}}
 	}
 
 	splitType := "h"
@@ -54,8 +57,9 @@ func splitsFromNode(n *layoutNode, commands map[string]string) []config.Split {
 		}
 		if c.Type == 0 {
 			entry.Command = paneCommand(commands, c.PaneID)
+			entry.Root = relPath(winBase, paths[c.PaneID])
 		} else {
-			entry.Children = splitsFromNode(c, commands)
+			entry.Children = splitsFromNode(c, commands, paths, winBase)
 		}
 		splits[i] = entry
 	}

--- a/internal/freeze/splits_test.go
+++ b/internal/freeze/splits_test.go
@@ -89,12 +89,41 @@ func TestSplitsFromNode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parseWindowLayout: %v", err)
 			}
-			got := splitsFromNode(root, tc.commands)
+			got := splitsFromNode(root, tc.commands, nil, "")
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("splitsFromNode() =\n%+v\nwant\n%+v", got, tc.want)
 			}
 		})
 	}
+
+	t.Run("with pane paths", func(t *testing.T) {
+		layout := "380d,200x50,0,0{139x50,0,0,0,60x50,140,0[60x24,140,0,1,60x25,140,25,2]}"
+		commands := map[string]string{
+			"%0": "nvim",
+			"%1": "npm run dev",
+			"%2": "cargo test",
+		}
+		paths := map[string]string{
+			"%0": "/my/project",
+			"%1": "/my/project/frontend",
+			"%2": "/my/project/backend",
+		}
+		root, err := parseWindowLayout(layout)
+		if err != nil {
+			t.Fatalf("parseWindowLayout: %v", err)
+		}
+		got := splitsFromNode(root, commands, paths, "/my/project")
+		want := []config.Split{
+			{Command: "nvim"},
+			{Type: "h", Size: 30, Children: []config.Split{
+				{Command: "npm run dev", Root: "frontend"},
+				{Type: "v", Size: 51, Command: "cargo test", Root: "backend"},
+			}},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("splitsFromNode with paths =\n%+v\nwant\n%+v", got, want)
+		}
+	})
 }
 
 func TestClampSize(t *testing.T) {

--- a/internal/session/integration_test.go
+++ b/internal/session/integration_test.go
@@ -2,6 +2,7 @@ package session_test
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/jskoll/wyrm/internal/config"
+	"github.com/jskoll/wyrm/internal/freeze"
 	"github.com/jskoll/wyrm/internal/session"
 	"github.com/jskoll/wyrm/internal/tmux"
 )
@@ -182,5 +184,127 @@ func TestIntegrationDottedSessionName(t *testing.T) {
 	}
 	if _, ok, err := tmux.FindSessionID(r, "wyrm.vim"); err != nil || ok {
 		t.Errorf("session still exists after Kill: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestIntegrationFreezeWorkingDirectoryRoundtrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	r := tmux.Exec{SocketName: fmt.Sprintf("wyrm-it-freeze-%d", os.Getpid())}
+	t.Cleanup(func() { r.Run("kill-server") }) //nolint:errcheck
+
+	root := t.TempDir()
+	frontendDir := filepath.Join(root, "frontend")
+	backendDir := filepath.Join(root, "backend")
+	docsDir := filepath.Join(root, "docs")
+	for _, d := range []string{frontendDir, backendDir, docsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		Session: config.Session{
+			Name: "freeze-dirs",
+			Root: root,
+		},
+		Windows: []config.Window{
+			{
+				Name: "web",
+				Root: "frontend",
+				Splits: []config.Split{
+					{Command: "# web-1"},
+					{Type: "h", Size: 50, Command: "# web-2"},
+				},
+			},
+			{
+				Name: "mixed",
+				Splits: []config.Split{
+					{Root: "backend", Command: "# api"},
+					{Type: "h", Size: 50, Root: "docs", Command: "# docs"},
+				},
+			},
+		},
+	}
+
+	_, sessionID, _, err := session.Create(r, cfg, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	frozen, err := freeze.Config(r, sessionID, "freeze-dirs-rebuilt", root)
+	if err != nil {
+		t.Fatalf("freeze.Config: %v", err)
+	}
+
+	if len(frozen.Windows) != 2 {
+		t.Fatalf("expected 2 windows in frozen config, got %d", len(frozen.Windows))
+	}
+	if frozen.Windows[0].Root != "frontend" {
+		t.Errorf("window 0 root = %q, want 'frontend'", frozen.Windows[0].Root)
+	}
+	if len(frozen.Windows[1].Splits) < 2 {
+		t.Fatalf("window 1 has %d splits, want at least 2", len(frozen.Windows[1].Splits))
+	}
+	if frozen.Windows[1].Splits[0].Root != "backend" {
+		t.Errorf("window 1 split 0 root = %q, want 'backend'", frozen.Windows[1].Splits[0].Root)
+	}
+	if frozen.Windows[1].Splits[1].Root != "docs" {
+		t.Errorf("window 1 split 1 root = %q, want 'docs'", frozen.Windows[1].Splits[1].Root)
+	}
+
+	// Kill and rebuild from frozen config
+	if _, err := session.Kill(r, cfg, io.Discard); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+
+	_, rebuiltID, _, err := session.Create(r, frozen, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("Create rebuilt: %v", err)
+	}
+
+	windows, err := tmux.ListWindows(r, rebuiltID)
+	if err != nil {
+		t.Fatalf("ListWindows rebuilt: %v", err)
+	}
+	if len(windows) != 2 {
+		t.Fatalf("rebuilt session has %d windows, want 2", len(windows))
+	}
+
+	samePath := func(a, b string) bool {
+		ea, erra := filepath.EvalSymlinks(a)
+		eb, errb := filepath.EvalSymlinks(b)
+		if erra == nil && errb == nil {
+			return filepath.Clean(ea) == filepath.Clean(eb)
+		}
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+
+	panes0, err := tmux.ListPanes(r, windows[0].ID)
+	if err != nil {
+		t.Fatalf("ListPanes window 0: %v", err)
+	}
+	for i, p := range panes0 {
+		if !samePath(p.Path, frontendDir) {
+			t.Errorf("window 0 pane %d path = %q, want %q", i, p.Path, frontendDir)
+		}
+	}
+
+	panes1, err := tmux.ListPanes(r, windows[1].ID)
+	if err != nil {
+		t.Fatalf("ListPanes window 1: %v", err)
+	}
+	if len(panes1) == 2 {
+		if !samePath(panes1[0].Path, backendDir) {
+			t.Errorf("window 1 pane 0 path = %q, want %q", panes1[0].Path, backendDir)
+		}
+		if !samePath(panes1[1].Path, docsDir) {
+			t.Errorf("window 1 pane 1 path = %q, want %q", panes1[1].Path, docsDir)
+		}
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -132,7 +132,18 @@ func Create(r tmux.Runner, cfg *config.Config, stdout, stderr io.Writer, opts ..
 	// The first window comes from new-session and the rest from new-window:
 	// different commands, different output shapes, and only the later ones leave
 	// a half-built session worth rolling back.
-	first, err := newSession(r, name, cfg.Windows[0], roots[0], env)
+	initRoots := make([]string, len(cfg.Windows))
+	for i, w := range cfg.Windows {
+		initRoot := roots[i]
+		if w.Root == "" && len(w.Splits) > 0 && w.Splits[0].Type == "" && w.Splits[0].Root != "" {
+			if ir, err := config.ResolveRoot(roots[i], w.Splits[0].Root); err == nil {
+				initRoot = ir
+			}
+		}
+		initRoots[i] = initRoot
+	}
+
+	first, err := newSession(r, name, cfg.Windows[0], initRoots[0], env)
 	if err != nil {
 		return "", "", false, err
 	}
@@ -151,7 +162,7 @@ func Create(r tmux.Runner, cfg *config.Config, stdout, stderr io.Writer, opts ..
 		windowID, paneID := first.windowID, first.paneID
 		if i > 0 {
 			var werr error
-			windowID, paneID, werr = newWindow(r, id, w, roots[i], env)
+			windowID, paneID, werr = newWindow(r, id, w, initRoots[i], env)
 			if werr != nil {
 				return "", "", false, rollback(r, id, stderr, werr)
 			}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -225,7 +225,7 @@ func TestCreateMultipleWindowsAndStartup(t *testing.T) {
 	// is %2.
 	r := &fakeRunner{
 		listWindowsOutput: "0|@1|0|layout|first\n1|@2|1|layout|second",
-		listPanesOutput:   map[string]string{"@2": "%2|1|1|zsh"},
+		listPanesOutput:   map[string]string{"@2": "%2|1|1|zsh|/tmp/proj"},
 	}
 	_, sessionID, _, err := Create(r, cfg, io.Discard, io.Discard)
 	if err != nil {

--- a/internal/tmux/inspect.go
+++ b/internal/tmux/inspect.go
@@ -21,6 +21,7 @@ type PaneInfo struct {
 	Index   int
 	Active  bool
 	Command string // #{pane_current_command}: the pane's foreground process
+	Path    string // #{pane_current_path}: the pane's current working directory
 }
 
 // SessionPath returns a session's working directory (#{session_path}) — the
@@ -219,7 +220,7 @@ func CheckIDs(sessionID, windowID, paneID string) error {
 	return nil
 }
 
-const paneListFormat = "#{pane_id}|#{pane_index}|#{?pane_active,1,0}|#{pane_current_command}"
+const paneListFormat = "#{pane_id}|#{pane_index}|#{?pane_active,1,0}|#{pane_current_command}|#{pane_current_path}"
 
 // ListPanes returns the panes of target (a window ID such as "@2", or a
 // session ID to list every pane in the session).
@@ -228,9 +229,20 @@ func ListPanes(r Runner, target string) ([]PaneInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listing panes: %w", CmdErr(err, out))
 	}
-	recs, err := records(out, 4, "list-panes")
-	if err != nil {
-		return nil, err
+	var recs [][]string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "|", 5)
+		if len(fields) < 4 {
+			return nil, fmt.Errorf("unexpected list-panes output %q", line)
+		}
+		if len(fields) == 4 {
+			fields = append(fields, "")
+		}
+		recs = append(recs, fields)
 	}
 	panes := make([]PaneInfo, 0, len(recs))
 	for _, f := range recs {
@@ -246,6 +258,7 @@ func ListPanes(r Runner, target string) ([]PaneInfo, error) {
 			Index:   index,
 			Active:  f[2] == "1",
 			Command: f[3],
+			Path:    f[4],
 		})
 	}
 	return panes, nil

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -249,14 +249,14 @@ func TestListWindowsMalformedLine(t *testing.T) {
 }
 
 func TestListPanes(t *testing.T) {
-	r := stubRunner{out: "%0|0|1|nvim\n%1|1|0|htop\n"}
+	r := stubRunner{out: "%0|0|1|nvim|/path/to/nvim\n%1|1|0|htop|/path/to/htop\n"}
 	panes, err := ListPanes(r, "@1")
 	if err != nil {
 		t.Fatalf("ListPanes: %v", err)
 	}
 	want := []PaneInfo{
-		{ID: "%0", Index: 0, Active: true, Command: "nvim"},
-		{ID: "%1", Index: 1, Active: false, Command: "htop"},
+		{ID: "%0", Index: 0, Active: true, Command: "nvim", Path: "/path/to/nvim"},
+		{ID: "%1", Index: 1, Active: false, Command: "htop", Path: "/path/to/htop"},
 	}
 	if len(panes) != len(want) {
 		t.Fatalf("ListPanes returned %d panes, want %d", len(panes), len(want))


### PR DESCRIPTION
## Summary
Resolves #34.

Captures `#{pane_current_path}` for each pane during `wyrm save` and `internal/freeze`:
- Resolves each pane's working directory relative to `session.root` (or preserves absolute path if outside the session root)
- Sets `Window.Root` when all panes within a window share a common subdirectory
- Sets `Split.Root` when individual splits have distinct working directories
- Sets the initial pane working directory during session creation when `Window.Root` is empty but `Splits[0].Root` is set
- Updated `ListPanes` to extract `#{pane_current_path}` with backwards compatibility for 4-field records

## Testing
- Unit tests in `internal/freeze/freeze_test.go` and `internal/freeze/splits_test.go`
- Integration test in `internal/session/integration_test.go` testing directory capture and rebuild roundtrips with real tmux
- `make lint`, `make test`, and `make cover` passed (81.2% coverage)