### PR TITLE
feat(config): support wyrm save --stdout and -n for dry-run config generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `--stdout` (or `-o -`) and `-n` / `--dry-run` flags in `wyrm save` to stream generated TOML directly to stdout or preview save results without touching disk.
+
 ## [1.0.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ way a bare `wyrm` would).
 ```sh
 wyrm save                  # writes .wyrm.toml (or the shared-storage path)
 wyrm save -config PATH     # write to PATH instead of the resolved location
+wyrm save --stdout         # print generated TOML to stdout (or -o -)
+wyrm save -n               # dry run preview without writing to disk
 ```
 
 tmux keeps no record of what was originally typed into a pane, so each

--- a/cmd_config.go
+++ b/cmd_config.go
@@ -215,10 +215,36 @@ func (a *app) edit(args []string) error {
 // hooks or comments.
 func (a *app) save(args []string) error {
 	fs := a.newFlagSet("save")
-	configPath := fs.String("config", "", "path to write the saved config (default: the discovered/shared location)")
+	var configPath, outputFlag string
+	var stdoutFlag bool
+	var dryRun, dryRunLong bool
+
+	fs.StringVar(&configPath, "config", "", "path to write the saved config (default: the discovered/shared location)")
+	fs.StringVar(&outputFlag, "o", "", "path to write the saved config, or '-' for stdout")
+	fs.BoolVar(&stdoutFlag, "stdout", false, "print the generated config to stdout instead of saving to disk")
+	fs.BoolVar(&dryRun, "n", false, "dry run: preview the save destination and generated config without writing to disk")
+	fs.BoolVar(&dryRunLong, "dry-run", false, "alias for -n")
+
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
+	if err := requireNoArgs(fs); err != nil {
+		return err
+	}
+
+	if outputFlag == "-" {
+		stdoutFlag = true
+	} else if outputFlag != "" {
+		if configPath != "" && configPath != outputFlag {
+			return usageErrf("cannot specify both -config and -o with different paths")
+		}
+		configPath = outputFlag
+	}
+
+	if stdoutFlag && configPath != "" {
+		return usageErrf("cannot specify both -stdout and -config")
+	}
+
 	settings, err := config.LoadSettings()
 	if err != nil {
 		return err
@@ -229,7 +255,20 @@ func (a *app) save(args []string) error {
 		return err
 	}
 
-	dest, err := a.saveDestination(settings, *configPath)
+	if stdoutFlag {
+		cfg, err := freeze.Config(a.runner, sessionID, sessionName, ".")
+		if err != nil {
+			return err
+		}
+		data, err := toml.Marshal(cfg)
+		if err != nil {
+			return err
+		}
+		_, err = a.stdout.Write(data)
+		return err
+	}
+
+	dest, err := a.saveDestination(settings, configPath)
 	if err != nil {
 		return err
 	}
@@ -241,6 +280,11 @@ func (a *app) save(args []string) error {
 	data, err := toml.Marshal(cfg)
 	if err != nil {
 		return err
+	}
+
+	if dryRun || dryRunLong {
+		_, _ = fmt.Fprintf(a.stdout, "# Dry run: would save session %s to %s\n%s", sessionName, dest, string(data))
+		return nil
 	}
 
 	if err := state.AtomicWriteFile(dest, data, 0o644); err != nil {

--- a/completions/_wyrm
+++ b/completions/_wyrm
@@ -51,6 +51,13 @@ _wyrm() {
                 up|restart|kill|edit|validate)
                     _arguments '-config[config file path]:config file:->configs'
                     ;;
+                save)
+                    _arguments '-config[config file path]:config file:->configs' \
+                        '-o[config file path or - for stdout]:config file:->configs' \
+                        '-stdout[print config to stdout]' \
+                        '-n[dry run preview]' \
+                        '-dry-run[dry run preview]'
+                    ;;
                 status)
                     _arguments '-format[output format]:format:(text json tmux waybar sketchybar)' \
                         '-session[filter to session]:session:' \

--- a/completions/wyrm.bash
+++ b/completions/wyrm.bash
@@ -47,6 +47,7 @@ _wyrm_complete() {
     if [[ "$cur" == -* ]]; then
         case "$cmd" in
             up|restart|kill|edit|validate) COMPREPLY=($(compgen -W "-config" -- "$cur")) ;;
+            save) COMPREPLY=($(compgen -W "-config -stdout -n -dry-run -o" -- "$cur")) ;;
             status) COMPREPLY=($(compgen -W "-format -session -v" -- "$cur")) ;;
             list) COMPREPLY=($(compgen -W "-format" -- "$cur")) ;;
             selfupdate) COMPREPLY=($(compgen -W "-check -version" -- "$cur")) ;;

--- a/completions/wyrm.fish
+++ b/completions/wyrm.fish
@@ -42,6 +42,11 @@ complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a '(wyrm lis
 
 # Subcommand flags.
 complete -c wyrm -n '__fish_seen_subcommand_from up restart kill edit validate' -o config -d 'config file path' -r -a '(wyrm list-configs 2>/dev/null)'
+complete -c wyrm -n '__fish_seen_subcommand_from save' -o config -d 'config file path' -r -a '(wyrm list-configs 2>/dev/null)'
+complete -c wyrm -n '__fish_seen_subcommand_from save' -o o -d 'config file path or - for stdout' -r
+complete -c wyrm -n '__fish_seen_subcommand_from save' -o stdout -d 'print config to stdout'
+complete -c wyrm -n '__fish_seen_subcommand_from save' -o n -d 'dry run preview'
+complete -c wyrm -n '__fish_seen_subcommand_from save' -o dry-run -d 'dry run preview'
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o format -d 'output format' -x -a 'text json tmux waybar sketchybar'
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o session -d 'filter to session' -x
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o v -d 'verbose output'

--- a/docs/index.md
+++ b/docs/index.md
@@ -326,6 +326,8 @@ way a bare `wyrm` would).
 ```sh
 wyrm save                  # writes .wyrm.toml (or the shared-storage path)
 wyrm save -config PATH     # write to PATH instead of the resolved location
+wyrm save --stdout         # print generated TOML to stdout (or -o -)
+wyrm save -n               # dry run preview without writing to disk
 ```
 
 tmux keeps no record of what was originally typed into a pane, so each

--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ Usage:
   wyrm kill [name]           destroy the session (runs on_project_exit first; -n to dry-run)
   wyrm pick                  fuzzy-pick a running session and attach to it
   wyrm tui                   full-screen session manager (browse, preview, manage)
-  wyrm save [-config PATH]   save the running session's layout as this folder's config
+  wyrm save [-config PATH]   save the running session's layout as this folder's config (-stdout, -n)
   wyrm edit [-config PATH]   open the resolved config in $EDITOR, creating one if needed
   wyrm validate [-config P]  check the effective config parses and validates (-strict)
   wyrm status [-format FMT]  print agent status across sessions (FMT: text, json, tmux, waybar, sketchybar)

--- a/main_test.go
+++ b/main_test.go
@@ -629,6 +629,94 @@ func TestRunSaveCurrentSessionError(t *testing.T) {
 	}
 }
 
+func TestRunSaveStdout(t *testing.T) {
+	chdir(t, t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		displayMessageOutput: "$3|myproj",
+		listWindowsOutput:    "0|@1|1|abcd,80x24,0,0,0|main",
+		listPanesOutput:      map[string]string{"@1": "%0|0|1|nvim"},
+	}
+	code := run([]string{"save", "-stdout"}, &stdout, &stderr, r, func() bool { return true }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `name = 'myproj'`) || !strings.Contains(out, `command = 'nvim'`) {
+		t.Errorf("stdout = %q, want TOML containing session name and command", out)
+	}
+	if _, err := os.Stat(config.DefaultFileName); err == nil {
+		t.Errorf("expected %s not to be created when -stdout is used", config.DefaultFileName)
+	}
+}
+
+func TestRunSaveOutputDash(t *testing.T) {
+	chdir(t, t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		displayMessageOutput: "$3|myproj",
+		listWindowsOutput:    "0|@1|1|abcd,80x24,0,0,0|main",
+		listPanesOutput:      map[string]string{"@1": "%0|0|1|nvim"},
+	}
+	code := run([]string{"save", "-o", "-"}, &stdout, &stderr, r, func() bool { return true }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `name = 'myproj'`) || !strings.Contains(out, `command = 'nvim'`) {
+		t.Errorf("stdout = %q, want TOML containing session name and command", out)
+	}
+}
+
+func TestRunSaveDryRun(t *testing.T) {
+	chdir(t, t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		displayMessageOutput: "$3|myproj",
+		listWindowsOutput:    "0|@1|1|abcd,80x24,0,0,0|main",
+		listPanesOutput:      map[string]string{"@1": "%0|0|1|nvim"},
+	}
+	code := run([]string{"save", "-n"}, &stdout, &stderr, r, func() bool { return true }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "# Dry run: would save session myproj to") {
+		t.Errorf("stdout = %q, want dry-run header", out)
+	}
+	if !strings.Contains(out, `name = 'myproj'`) {
+		t.Errorf("stdout = %q, want generated TOML in dry run preview", out)
+	}
+	if _, err := os.Stat(config.DefaultFileName); err == nil {
+		t.Errorf("expected %s not to be created under -n", config.DefaultFileName)
+	}
+}
+
+func TestRunSaveIncompatibleFlags(t *testing.T) {
+	chdir(t, t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		displayMessageOutput: "$3|myproj",
+	}
+
+	// -stdout with -config
+	code := run([]string{"save", "-stdout", "-config", "custom.toml"}, &stdout, &stderr, r, func() bool { return true }, nil)
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for incompatible flags", code)
+	}
+
+	// -o mismatch with -config
+	stderr.Reset()
+	code = run([]string{"save", "-config", "a.toml", "-o", "b.toml"}, &stdout, &stderr, r, func() bool { return true }, nil)
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for conflicting config and -o", code)
+	}
+}
+
 func TestRunListTable(t *testing.T) {
 	r := &fakeRunner{listOutput: strings.Join([]string{
 		"$1|3|1|2000|alpha",

--- a/man/wyrm.1
+++ b/man/wyrm.1
@@ -63,8 +63,14 @@ Fuzzy-pick a running session and attach to it.
 Open the full-screen session manager: browse, preview, kill, rename, and
 start sessions.
 .TP
-.BI "wyrm save [\-config " PATH ]
+.BI "wyrm save [\-config " PATH "] [\-stdout] [\-n] [\-o " PATH ]
 Save the running session's current layout as this folder's config.
+.B \-stdout
+(or
+.BR "\-o -" )
+prints the generated TOML to standard output without touching the filesystem.
+.B \-n
+previews the destination and generated config without writing to disk.
 Refuses to overwrite an existing config file.
 .TP
 .BI "wyrm edit [\-config " PATH ]


### PR DESCRIPTION
## Summary
Resolves #35.

Adds support for dry-run config generation and stdout streaming in `wyrm save`:
- `--stdout` (and `-o -`) prints generated TOML directly to stdout without checking or creating files
- `-n` / `--dry-run` previews the resolved save destination and generated TOML without touching the filesystem
- Validates mutual exclusivity between `-stdout` and explicit file paths (`-config`)
- Updated shell completions (Bash, Fish, Zsh) and man page `wyrm.1`

## Testing
- Added unit tests in `main_test.go` (`TestRunSaveStdout`, `TestRunSaveOutputDash`, `TestRunSaveDryRun`, `TestRunSaveIncompatibleFlags`)
- `make lint`, `make test`, and `make cover` passed (81.1% statement coverage)