### PR TITLE
feat(config): support per-pane and per-window environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Support for per-window (`[windows.env]`) and per-split (`[windows.splits.env]`) environment variables, cascaded with precedence: Split > Window > Session.
+
 ## [1.0.0] - 2026-08-15
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,6 +296,7 @@ with a bigger hook.
 |---|---|---|---|
 | `name` | string | — | Window name |
 | `root` | string | session root | This window's working directory. A relative path resolves against `session.root`, so `root = "api"` means the `api` folder inside the project |
+| `env` | table | — | Environment variables set for all panes of this window, overriding `session.env` |
 | `pre_window` | string | — | Command typed once into **every pane of the window**, before that pane's own command (e.g. `nvm use 18`) |
 | `post_window` | string | — | Shell command **run** (not typed) once all of the window's panes and their commands exist |
 | `splits` | list | — | Split tree (below) — the recommended layout format |
@@ -329,6 +330,7 @@ A failure warns and continues, same as every other per-window failure — see
 | `command` | string | — | **Typed** into the pane's shell; entries starting with `#` are comments and skipped |
 | `run` | string | — | **Run** as the pane's own process, with no shell under it (below). Mutually exclusive with `command` |
 | `root` | string | window root | This pane's working directory, relative to the window's root unless absolute |
+| `env` | table | — | Environment variables for this pane and its children, overriding window and session env |
 | `children` | list | — | Nested splits, applied inside this entry's pane |
 
 ### `command` vs `run`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,10 +99,11 @@ type Window struct {
 	// Before this existed the only way to express it was pre_window = "cd api",
 	// which types a visible cd into every pane of the window and races that
 	// pane's own command.
-	Root      string  `toml:"root,omitempty"`
-	Splits    []Split `toml:"splits,omitempty"`
-	Panes     []Pane  `toml:"panes,omitempty"`
-	PreWindow string  `toml:"pre_window,omitempty"`
+	Root      string            `toml:"root,omitempty"`
+	Env       map[string]string `toml:"env,omitempty"`
+	Splits    []Split           `toml:"splits,omitempty"`
+	Panes     []Pane            `toml:"panes,omitempty"`
+	PreWindow string            `toml:"pre_window,omitempty"`
 	// PostWindow is a shell command run (via your $SHELL, or sh, in the
 	// window's root) once all of the window's panes exist, splits and pane
 	// commands included. Unlike PreWindow, it is a real subprocess — not
@@ -136,8 +137,9 @@ type Split struct {
 	Run string `toml:"run,omitempty"`
 	// Root overrides the window's directory for this pane and, unless they
 	// override it themselves, its children.
-	Root     string  `toml:"root,omitempty"`
-	Children []Split `toml:"children,omitempty"`
+	Root     string            `toml:"root,omitempty"`
+	Env      map[string]string `toml:"env,omitempty"`
+	Children []Split           `toml:"children,omitempty"`
 	// RemainOnExit keeps this pane open after its command exits.
 	RemainOnExit *bool `toml:"remain_on_exit,omitempty"`
 	// Zoomed starts this split focused and zoomed.
@@ -264,11 +266,29 @@ func (c *Config) validate() error {
 	default:
 		return fmt.Errorf("session.pane_title_position must be %q or %q, got %q", "top", "bottom", c.Session.PaneTitlePosition)
 	}
+	if err := validateEnv("session.env", c.Session.Env); err != nil {
+		return err
+	}
 	for _, w := range c.Windows {
+		if err := validateEnv(fmt.Sprintf("window %q env", w.Name), w.Env); err != nil {
+			return err
+		}
 		if err := validateSplits(w.Name, w.Splits); err != nil {
 			return err
 		}
 		c.warnings = append(c.warnings, windowWarnings(w)...)
+	}
+	return nil
+}
+
+func validateEnv(where string, env map[string]string) error {
+	for k := range env {
+		if k == "" {
+			return fmt.Errorf("%s: empty environment variable name", where)
+		}
+		if strings.Contains(k, "=") || strings.Contains(k, "\x00") {
+			return fmt.Errorf("%s: invalid environment variable name %q", where, k)
+		}
 	}
 	return nil
 }
@@ -303,6 +323,9 @@ func windowWarnings(w Window) []string {
 
 func validateSplits(window string, splits []Split) error {
 	for i, s := range splits {
+		if err := validateEnv(fmt.Sprintf("window %q split %d env", window, i), s.Env); err != nil {
+			return err
+		}
 		// 0 means "let tmux decide", so it's accepted alongside 1-99.
 		if s.Size < 0 || s.Size > 99 {
 			return fmt.Errorf("window %q split %d: size must be 1-99 (or omitted for tmux's default), got %d", window, i, s.Size)
@@ -492,6 +515,9 @@ func (c *Config) Interpolate(vars map[string]string) {
 		c.Windows[i].Root = InterpolateString(c.Windows[i].Root, vars)
 		c.Windows[i].PreWindow = InterpolateString(c.Windows[i].PreWindow, vars)
 		c.Windows[i].PostWindow = InterpolateString(c.Windows[i].PostWindow, vars)
+		for k, v := range c.Windows[i].Env {
+			c.Windows[i].Env[k] = InterpolateString(v, vars)
+		}
 		interpolateSplits(c.Windows[i].Splits, vars)
 		for j := range c.Windows[i].Panes {
 			c.Windows[i].Panes[j].Command = InterpolateString(c.Windows[i].Panes[j].Command, vars)
@@ -504,6 +530,9 @@ func interpolateSplits(splits []Split, vars map[string]string) {
 		splits[i].Command = InterpolateString(splits[i].Command, vars)
 		splits[i].Run = InterpolateString(splits[i].Run, vars)
 		splits[i].Root = InterpolateString(splits[i].Root, vars)
+		for k, v := range splits[i].Env {
+			splits[i].Env[k] = InterpolateString(v, vars)
+		}
 		interpolateSplits(splits[i].Children, vars)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -396,6 +396,9 @@ enable_pane_titles = true
 pane_title_position = "top"
 pane_title_format = "#{pane_index}"
 
+[session.env]
+GLOBAL = "1"
+
 [[windows]]
 name = "w"
 layout = "tiled"
@@ -405,6 +408,9 @@ synchronize = true
 synchronize_panes = true
 remain_on_exit = true
 
+[windows.env]
+WIN = "2"
+
   [[windows.splits]]
   type = "h"
   size = 30
@@ -412,6 +418,9 @@ remain_on_exit = true
   remain_on_exit = true
   zoomed = true
   zoom = true
+
+  [windows.splits.env]
+  SPLIT = "3"
 
     [[windows.splits.children]]
     type = "v"
@@ -593,5 +602,110 @@ func TestInterpolateString(t *testing.T) {
 				t.Errorf("InterpolateString(%q, %v) = %q, want %q", tt.input, tt.vars, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestWindowAndSplitEnvValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		toml    string
+		wantErr bool
+	}{
+		{
+			name: "valid window and split env",
+			toml: `
+[session]
+name = "test"
+[session.env]
+A = "1"
+
+[[windows]]
+name = "w"
+[windows.env]
+PORT = "8080"
+[[windows.splits]]
+command = "ls"
+[windows.splits.env]
+NODE_ENV = "test"
+`,
+			wantErr: false,
+		},
+		{
+			name: "invalid window env with equals",
+			toml: `
+[session]
+name = "test"
+[[windows]]
+name = "w"
+[windows.env]
+"A=B" = "1"
+[[windows.splits]]
+command = "ls"
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid split env with null",
+			toml: `
+[session]
+name = "test"
+[[windows]]
+name = "w"
+[[windows.splits]]
+command = "ls"
+[windows.splits.env]
+"A\u0000B" = "1"
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConfig(t, tt.toml)
+			cfg, err := Load(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Load() expected error, got cfg: %+v", cfg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Load() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestWindowAndSplitEnvInterpolation(t *testing.T) {
+	raw := `
+[session]
+name = "test"
+
+[[windows]]
+name = "w"
+[windows.env]
+PORT = "{{PORT}}"
+[[windows.splits]]
+command = "run"
+[windows.splits.env]
+HOST = "{{HOST}}"
+`
+	path := writeConfig(t, raw)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg.Interpolate(map[string]string{
+		"PORT": "9000",
+		"HOST": "127.0.0.1",
+	})
+
+	if cfg.Windows[0].Env["PORT"] != "9000" {
+		t.Errorf("Windows[0].Env[PORT] = %q, want '9000'", cfg.Windows[0].Env["PORT"])
+	}
+	if cfg.Windows[0].Splits[0].Env["HOST"] != "127.0.0.1" {
+		t.Errorf("Splits[0].Env[HOST] = %q, want '127.0.0.1'", cfg.Windows[0].Splits[0].Env["HOST"])
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -115,14 +115,23 @@ func Create(r tmux.Runner, cfg *config.Config, stdout, stderr io.Writer, opts ..
 	// Every window's root is resolved up front so a bad one fails before any
 	// tmux state exists, rather than half way through a build.
 	roots := make([]string, len(cfg.Windows))
+	winEnvs := make([]map[string]string, len(cfg.Windows))
+	initEnvs := make([]map[string]string, len(cfg.Windows))
 	for i, w := range cfg.Windows {
 		wr, rerr := config.ResolveRoot(root, w.Root)
 		if rerr != nil {
 			return "", "", false, fmt.Errorf("window %q: %w", w.Name, rerr)
 		}
 		roots[i] = wr
+
+		we := mergeEnv(cfg.Session.Env, w.Env)
+		winEnvs[i] = we
+		ie := we
+		if len(w.Splits) > 0 && w.Splits[0].Type == "" {
+			ie = mergeEnv(we, w.Splits[0].Env)
+		}
+		initEnvs[i] = ie
 	}
-	env := envArgs(cfg.Session.Env)
 
 	// Commands are collected while the layout is built and typed in one tmux
 	// process afterwards — see keyBatch. In a three-window, six-pane build that
@@ -132,7 +141,7 @@ func Create(r tmux.Runner, cfg *config.Config, stdout, stderr io.Writer, opts ..
 	// The first window comes from new-session and the rest from new-window:
 	// different commands, different output shapes, and only the later ones leave
 	// a half-built session worth rolling back.
-	first, err := newSession(r, name, cfg.Windows[0], roots[0], env)
+	first, err := newSession(r, name, cfg.Windows[0], roots[0], envArgs(initEnvs[0]))
 	if err != nil {
 		return "", "", false, err
 	}
@@ -151,14 +160,14 @@ func Create(r tmux.Runner, cfg *config.Config, stdout, stderr io.Writer, opts ..
 		windowID, paneID := first.windowID, first.paneID
 		if i > 0 {
 			var werr error
-			windowID, paneID, werr = newWindow(r, id, w, roots[i], env)
+			windowID, paneID, werr = newWindow(r, id, w, roots[i], envArgs(initEnvs[i]))
 			if werr != nil {
 				return "", "", false, rollback(r, id, stderr, werr)
 			}
 		}
 		_, _ = fmt.Fprintf(stdout, "window %s: %s\n", windowID, w.Name)
 		buildWindow(r, windowID, paneID, w, splitCtx{
-			root: roots[i], env: env, preWindow: w.PreWindow, keys: keys,
+			root: roots[i], envMap: winEnvs[i], preWindow: w.PreWindow, keys: keys,
 		}, stderr)
 	}
 
@@ -170,7 +179,7 @@ func Create(r tmux.Runner, cfg *config.Config, stdout, stderr io.Writer, opts ..
 	// been sent first, not just the pane to exist. Sequential and in window
 	// order, matching the order windows were built in.
 	for i, w := range cfg.Windows {
-		if err := runHook(o, w.PostWindow, roots[i], "post_window", cfg.Session.Env, stderr); err != nil {
+		if err := runHook(o, w.PostWindow, roots[i], "post_window", winEnvs[i], stderr); err != nil {
 			warnf(stderr, "post_window failed for window %q: %v", w.Name, err)
 		}
 	}
@@ -396,7 +405,7 @@ func buildWindow(r tmux.Runner, windowID, initialPane string, w config.Window, c
 // pre_window command, and the per-pane record of where it has already run.
 type splitCtx struct {
 	root          string
-	env           []string
+	envMap        map[string]string
 	preWindow     string
 	done          map[string]bool
 	keys          *keyBatch
@@ -418,6 +427,7 @@ type splitCtx struct {
 func applySplits(r tmux.Runner, basePane string, splits []config.Split, ctx splitCtx, stderr io.Writer) {
 	panes := make([]string, len(splits))
 	roots := make([]string, len(splits))
+	splitEnvs := make([]map[string]string, len(splits))
 	current := basePane
 	for i, s := range splits {
 		root, err := config.ResolveRoot(ctx.root, s.Root)
@@ -426,10 +436,12 @@ func applySplits(r tmux.Runner, basePane string, splits []config.Split, ctx spli
 			root = ctx.root
 		}
 		roots[i] = root
+		splitEnv := mergeEnv(ctx.envMap, s.Env)
+		splitEnvs[i] = splitEnv
 
 		pane := current
 		if s.Type != "" {
-			newPane, err := splitPane(r, current, s, root, ctx.env)
+			newPane, err := splitPane(r, current, s, root, envArgs(splitEnv))
 			if err != nil {
 				warnf(stderr, "failed to split pane: %v", err)
 				continue // panes[i] stays "": skipped below
@@ -466,6 +478,7 @@ func applySplits(r tmux.Runner, basePane string, splits []config.Split, ctx spli
 		}
 		child := ctx
 		child.root = roots[i]
+		child.envMap = splitEnvs[i]
 		if len(s.Children) > 0 && s.Children[0].Type == "" && ctx.onPaneCreated != nil {
 			ctx.onPaneCreated(pane, s.Children[0])
 		}
@@ -526,7 +539,7 @@ func applyPanes(r tmux.Runner, windowID, initialPane string, w config.Window, ct
 		if ctx.root != "" {
 			args = append(args, "-c", ctx.root) // see splitPane
 		}
-		args = append(args, ctx.env...)
+		args = append(args, envArgs(ctx.envMap)...)
 		out, err := r.Run(args...)
 		if err != nil {
 			warnf(stderr, "failed to split pane: %v (%s)", err, out)
@@ -819,4 +832,18 @@ func hookEnv(env map[string]string) []string {
 
 func warnf(w io.Writer, format string, args ...any) {
 	_, _ = fmt.Fprintf(w, "wyrm: warning: "+format+"\n", args...)
+}
+
+func mergeEnv(parent, child map[string]string) map[string]string {
+	if len(parent) == 0 && len(child) == 0 {
+		return nil
+	}
+	res := make(map[string]string, len(parent)+len(child))
+	for k, v := range parent {
+		res[k] = v
+	}
+	for k, v := range child {
+		res[k] = v
+	}
+	return res
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -973,6 +973,91 @@ func TestCreatePassesEnv(t *testing.T) {
 	}
 }
 
+func TestCreateCascadesEnv(t *testing.T) {
+	cfg := &config.Config{
+		Session: config.Session{
+			Name: "proj",
+			Root: "/tmp/proj",
+			Env: map[string]string{
+				"GLOBAL":   "1",
+				"OVERRIDE": "session",
+				"PORT":     "3000",
+			},
+		},
+		Windows: []config.Window{
+			{
+				Name: "api",
+				Env: map[string]string{
+					"OVERRIDE": "window",
+					"API_KEY":  "secret",
+				},
+				Splits: []config.Split{
+					{
+						Env:     map[string]string{"OVERRIDE": "split0"},
+						Command: "npm run dev",
+					},
+					{
+						Type:    "h",
+						Env:     map[string]string{"OVERRIDE": "split1", "SUB": "child"},
+						Command: "npm test",
+					},
+				},
+			},
+			{
+				Name: "web",
+				Splits: []config.Split{
+					{
+						Env:     map[string]string{"PORT": "4000"},
+						Command: "python app.py",
+					},
+				},
+			},
+		},
+	}
+
+	r := &fakeRunner{}
+	if _, _, _, err := Create(r, cfg, io.Discard, io.Discard); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	calls := r.joined()
+	// Check new-session (window 0 initial pane)
+	newSessionCall := ""
+	for _, c := range calls {
+		if strings.HasPrefix(c, "new-session") {
+			newSessionCall = c
+			break
+		}
+	}
+	if newSessionCall == "" || !strings.Contains(newSessionCall, "-e API_KEY=secret -e GLOBAL=1 -e OVERRIDE=split0 -e PORT=3000") {
+		t.Errorf("new-session call %q missing cascaded env", newSessionCall)
+	}
+
+	// Check split-window (window 0 split 1)
+	splitCall := ""
+	for _, c := range calls {
+		if strings.HasPrefix(c, "split-window") {
+			splitCall = c
+			break
+		}
+	}
+	if splitCall == "" || !strings.Contains(splitCall, "-e API_KEY=secret -e GLOBAL=1 -e OVERRIDE=split1 -e PORT=3000 -e SUB=child") {
+		t.Errorf("split-window call %q missing cascaded env", splitCall)
+	}
+
+	// Check new-window (window 1 initial pane)
+	newWinCall := ""
+	for _, c := range calls {
+		if strings.HasPrefix(c, "new-window") {
+			newWinCall = c
+			break
+		}
+	}
+	if newWinCall == "" || !strings.Contains(newWinCall, "-e GLOBAL=1 -e OVERRIDE=session -e PORT=4000") {
+		t.Errorf("new-window call %q missing cascaded env", newWinCall)
+	}
+}
+
 // batchingRunner is a fakeRunner that also implements tmux.BatchRunner, so a
 // test can see that the build actually batches rather than quietly falling back
 // to one call per command — which is what every other mock here does.


### PR DESCRIPTION
## Summary
Resolves #36.

Adds support for granular environment variables at the window and split levels:
- Extended `config.Window` and `config.Split` with `Env map[string]string`
- Cascades environment variables with precedence: `Split.Env` > `Window.Env` > `Session.Env`
- Injects cascaded `-e KEY=VALUE` parameters into `new-session`, `new-window`, and `split-window`
- Enables variable interpolation and syntax validation on all env maps
- Updated documentation in `docs/configuration.md`

## Testing
- Unit tests in `internal/config/config_test.go` (`TestWindowAndSplitEnvValidation`, `TestWindowAndSplitEnvInterpolation`, and strict schema test)
- Unit tests in `internal/session/session_test.go` (`TestCreateCascadesEnv`)
- `make lint`, `make test`, and `make cover` passed (81.2% statement coverage)