### PR TITLE
feat(config): upward directory traversal to discover .wyrm.toml at project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Upward directory traversal to automatically discover `.wyrm.toml` at Git repository or project root from nested subdirectories, with configurable `[discovery].upward` setting (enabled by default).
+
 ## [1.0.0] - 2026-08-15
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,6 +189,22 @@ with its own config or a `~`-marked wildcard match. This is a `wyrm
 tui`-only feature — `wyrm <name>` and `wyrm pick` don't resolve zoxide
 directories by name.
 
+## `[discovery]` — upward config traversal
+
+When `wyrm` is run inside a subdirectory of a repository or project, it
+automatically traverses parent directories to find the repository's `.wyrm.toml`.
+Traversal stops at git repository boundaries (`.git`), the user's home
+directory, or the filesystem root.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `discovery.upward` | bool | `true` | Walk upward from the current working directory to find `.wyrm.toml` |
+
+```toml
+[discovery]
+upward = true
+```
+
 ## Custom default config
 
 When no project config is found at all, wyrm falls back to

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,14 +152,72 @@ type Pane struct {
 }
 
 // Discover returns the config file to use when none was given: DefaultFileName
-// in the current directory, falling back to LegacyFileName.
+// in the current directory, falling back to LegacyFileName, or searching upward
+// through parent directories up to a git repository root or user home directory.
 func Discover() (string, error) {
-	for _, name := range []string{DefaultFileName, LegacyFileName} {
-		if _, err := os.Stat(name); err == nil {
-			return name, nil
+	return DiscoverIn(".", true)
+}
+
+// DiscoverIn searches for a config file starting at startDir. If upward is true,
+// it walks upward through parent directories until it finds a config, reaches
+// a git repository boundary (.git), reaches the user home directory, or hits the
+// filesystem root.
+func DiscoverIn(startDir string, upward bool) (string, error) {
+	dir := startDir
+	if dir == "" || dir == "." {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
 		}
+		dir = cwd
 	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+
+	homeDir, _ := os.UserHomeDir()
+	if homeDir != "" {
+		homeDir, _ = filepath.Abs(homeDir)
+	}
+
+	current := absDir
+	for {
+		for _, name := range []string{DefaultFileName, LegacyFileName} {
+			target := filepath.Join(current, name)
+			if _, err := os.Stat(target); err == nil {
+				if current == absDir {
+					return name, nil
+				}
+				return target, nil
+			}
+		}
+
+		if !upward {
+			break
+		}
+
+		if isGitRoot(current) {
+			break
+		}
+		if homeDir != "" && current == homeDir {
+			break
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+
 	return "", fmt.Errorf("no %s or %s in the current directory (or pass -config)", DefaultFileName, LegacyFileName)
+}
+
+func isGitRoot(dir string) bool {
+	gitPath := filepath.Join(dir, ".git")
+	_, err := os.Stat(gitPath)
+	return err == nil
 }
 
 // Load reads, parses, and validates a config file.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -347,6 +347,63 @@ func TestDiscover(t *testing.T) {
 	}
 }
 
+func TestDiscoverUpwardInGitRepo(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(repoRoot, DefaultFileName)
+	if err := os.WriteFile(cfgPath, []byte("[session]\nname = 'myrepo'\n[[windows]]\nname = 'w'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nestedDir := filepath.Join(repoRoot, "src", "packages", "ui")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	chdir(t, nestedDir)
+
+	got, err := Discover()
+	if err != nil {
+		t.Fatalf("Discover from nested dir: %v", err)
+	}
+	if filepath.Clean(got) != filepath.Clean(cfgPath) {
+		t.Errorf("Discover() = %q, want %q", got, cfgPath)
+	}
+
+	cfg, err := Load(got)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if filepath.Clean(cfg.Dir()) != filepath.Clean(repoRoot) {
+		t.Errorf("cfg.Dir() = %q, want %q", cfg.Dir(), repoRoot)
+	}
+}
+
+func TestDiscoverUpwardHaltsAtGitRoot(t *testing.T) {
+	outerDir := t.TempDir()
+	outerCfg := filepath.Join(outerDir, DefaultFileName)
+	if err := os.WriteFile(outerCfg, []byte("[session]\nname = 'outer'\n[[windows]]\nname = 'w'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	innerRepo := filepath.Join(outerDir, "inner")
+	if err := os.MkdirAll(filepath.Join(innerRepo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(innerRepo, "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	chdir(t, nested)
+
+	if got, err := Discover(); err == nil {
+		t.Errorf("Discover() = %q, expected error because traversal should halt at inner .git boundary", got)
+	}
+}
+
 // TestLoadWarnsOnUnknownKeys: a misspelled key is dropped silently by a plain
 // TOML unmarshal, so a config whose every key was a typo passed `wyrm validate`
 // — the exact mistake validate exists to catch.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -53,16 +53,32 @@ const (
 
 // Settings is wyrm's global preferences, shared across all projects.
 type Settings struct {
-	Storage   Storage    `toml:"storage"`
-	SharedDir string     `toml:"shared_dir"`
-	TUI       TUI        `toml:"tui"`
-	Tmux      Tmux       `toml:"tmux"`
-	Wildcard  []Wildcard `toml:"wildcard,omitempty"`
-	Zoxide    Zoxide     `toml:"zoxide"`
+	Storage   Storage           `toml:"storage"`
+	SharedDir string            `toml:"shared_dir"`
+	TUI       TUI               `toml:"tui"`
+	Tmux      Tmux              `toml:"tmux"`
+	Wildcard  []Wildcard        `toml:"wildcard,omitempty"`
+	Zoxide    Zoxide            `toml:"zoxide"`
+	Discovery DiscoverySettings `toml:"discovery"`
 
 	// warnings collects unknown top-level keys found while parsing this
 	// settings file (see LoadSettings), mirroring Config.warnings.
 	warnings []string
+}
+
+// DiscoverySettings configures config file discovery options.
+type DiscoverySettings struct {
+	// Upward enables traversing up parent directories to find .wyrm.toml.
+	// Defaults to true.
+	Upward *bool `toml:"upward"`
+}
+
+// UpwardDiscoveryEnabled returns true unless discovery.upward is explicitly false.
+func (s *Settings) UpwardDiscoveryEnabled() bool {
+	if s == nil || s.Discovery.Upward == nil {
+		return true
+	}
+	return *s.Discovery.Upward
 }
 
 // Zoxide configures the TUI's optional zoxide-backed directory discovery —
@@ -480,11 +496,11 @@ func EditTarget(settings *Settings) (path string, exists bool, err error) {
 // falling back to Discover's normal current-directory search if that file
 // doesn't exist.
 func DiscoverGlobal(settings *Settings) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
 	if settings != nil && settings.Storage == StorageShared {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
 		shared, err := settings.SharedConfigPath(cwd)
 		if err != nil {
 			return "", err
@@ -493,5 +509,9 @@ func DiscoverGlobal(settings *Settings) (string, error) {
 			return shared, nil
 		}
 	}
-	return Discover()
+	upward := true
+	if settings != nil {
+		upward = settings.UpwardDiscoveryEnabled()
+	}
+	return DiscoverIn(cwd, upward)
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -173,6 +173,9 @@ config = "~/.config/wyrm/settings/_template.wyrm.toml"
 [zoxide]
 enabled = true
 track = true
+
+[discovery]
+upward = true
 `
 	if err := os.WriteFile(filepath.Join(dir, SettingsFileName), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
@@ -465,6 +468,38 @@ func TestDiscoverGlobalLocalMode(t *testing.T) {
 	if got, err := DiscoverGlobal(settings); err != nil || got != DefaultFileName {
 		t.Errorf("DiscoverGlobal = %q, %v, want %q, nil", got, err, DefaultFileName)
 	}
+}
+
+func TestDiscoverGlobalUpwardSetting(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(repoRoot, DefaultFileName)
+	if err := os.WriteFile(cfgPath, []byte("[session]\nname = 'up'\n[[windows]]\nname = 'w'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "sub", "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, nested)
+
+	// Upward explicitly disabled:
+	disabled := &Settings{Discovery: DiscoverySettings{Upward: boolPtr(false)}}
+	if got, err := DiscoverGlobal(disabled); err == nil {
+		t.Errorf("DiscoverGlobal with upward=false: got %q, want error", got)
+	}
+
+	// Upward enabled (default or explicit):
+	enabled := &Settings{Discovery: DiscoverySettings{Upward: boolPtr(true)}}
+	if got, err := DiscoverGlobal(enabled); err != nil || filepath.Clean(got) != filepath.Clean(cfgPath) {
+		t.Errorf("DiscoverGlobal with upward=true: got %q, %v, want %q, nil", got, err, cfgPath)
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 // The [tui] section is optional in every direction: an absent file, an absent


### PR DESCRIPTION
## Summary
Resolves #38.

Adds upward directory traversal to automatically find `.wyrm.toml` when running `wyrm` from subdirectories:
- `DiscoverIn` searches parent directories stopping at git repository root (`.git`), user home directory, or filesystem root
- Relative paths and session root properly resolve relative to the discovered config file's directory
- Added global setting `[discovery].upward = true` in `~/.config/wyrm/config.toml` (enabled by default)
- Updated documentation in `docs/configuration.md`

## Testing
- Unit tests in `internal/config/config_test.go` (`TestDiscoverUpwardInGitRepo`, `TestDiscoverUpwardHaltsAtGitRoot`)
- Unit tests in `internal/config/settings_test.go` (`TestDiscoverGlobalUpwardSetting`, strict schema test)
- `make lint`, `make test`, and `make cover` passed (81.2% statement coverage)