### PR TITLE
feat(session): bulk session operations: wyrm kill --all and wyrm restart --all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Bulk session operations: `--all` (or `-a`) and `--yes` (or `-y`) flags for `wyrm kill` and `wyrm restart` to gracefully stop or rebuild all active tmux sessions.
+
 ## [1.0.0] - 2026-08-15
 
 ### Added

--- a/cmd_session.go
+++ b/cmd_session.go
@@ -142,18 +142,38 @@ func (a *app) restart(args []string) error {
 	configPath := fs.String("config", "", "path to config file (default: .wyrm.toml, then .tmuxconfig)")
 	dryRun := fs.Bool("n", false, "print the tmux commands and hooks that would run, without touching tmux")
 	detach := fs.Bool("d", false, "build the session without attaching")
+	allFlag := fs.Bool("all", false, "restart all active tmux sessions")
+	allShort := fs.Bool("a", false, "alias for -all")
+	yesFlag := fs.Bool("y", false, "skip confirmation prompt when restarting all sessions")
+	yesLong := fs.Bool("yes", false, "alias for -y")
 	var vars varMapFlag
 	fs.Var(&vars, "var", "set template variable (KEY=VALUE, can be repeated)")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
-	if err := requireNoArgs(fs); err != nil {
-		return err
-	}
+
+	all := *allFlag || *allShort
+	yes := *yesFlag || *yesLong
+
 	settings, err := config.LoadSettings()
 	if err != nil {
 		return err
 	}
+
+	if all {
+		if *configPath != "" {
+			return usageErrf("-config and -all are mutually exclusive")
+		}
+		if fs.NArg() > 0 {
+			return usageErrf("session name and -all are mutually exclusive")
+		}
+		return a.restartAll(settings, *dryRun, yes, vars)
+	}
+
+	if err := requireNoArgs(fs); err != nil {
+		return err
+	}
+
 	cfg, _, err := a.resolveConfig(settings, *configPath)
 	if err != nil {
 		return err
@@ -198,6 +218,77 @@ func (a *app) restart(args []string) error {
 	return a.attachOrSwitch(sessionID)
 }
 
+func (a *app) restartAll(settings *config.Settings, dryRun, yes bool, vars map[string]string) error {
+	active, err := sessions.List(a.runner)
+	if err != nil {
+		return err
+	}
+	if len(active) == 0 {
+		_, _ = fmt.Fprintln(a.stdout, "no active sessions to restart")
+		return nil
+	}
+
+	if !dryRun && !yes {
+		if !a.promptConfirm(fmt.Sprintf("Restart all %d active tmux session(s)? (y/N): ", len(active))) {
+			_, _ = fmt.Fprintln(a.stdout, "aborted")
+			return nil
+		}
+	}
+
+	hist, err := state.Load()
+	if err != nil {
+		return err
+	}
+
+	var opts []session.Option
+	if dryRun {
+		opts = a.teardownDryRun()
+	}
+
+	for _, s := range active {
+		project, found := config.FindProject(settings, s.Name)
+		if !found {
+			_, _ = fmt.Fprintf(a.stderr, "wyrm: skipping session %q: no project config found\n", s.Name)
+			continue
+		}
+		cfg, err := config.Load(project.Path)
+		if err != nil {
+			_, _ = fmt.Fprintf(a.stderr, "wyrm: warning: skipping session %q: %v\n", s.Name, err)
+			continue
+		}
+		if len(vars) > 0 {
+			cfg.Interpolate(vars)
+		}
+
+		if dryRun {
+			_, _ = fmt.Fprintf(a.stdout, "# Restarting session %s (%s)\n", s.Name, project.Path)
+			if _, kerr := session.Kill(a.runner, cfg, a.stderr, opts...); kerr != nil {
+				_, _ = fmt.Fprintf(a.stderr, "wyrm: nothing to stop (%v)\n", kerr)
+			}
+			dry := tmux.NewDryRun(a.stdout)
+			_, _, _, err := session.Create(dry, cfg, io.Discard, a.stderr, session.DryRun(a.stdout), session.WithHistory(hist))
+			if err != nil {
+				_, _ = fmt.Fprintf(a.stderr, "wyrm: warning: dry-run create failed for %s: %v\n", s.Name, err)
+			}
+			continue
+		}
+
+		if name, kerr := session.Kill(a.runner, cfg, a.stderr); kerr != nil {
+			_, _ = fmt.Fprintf(a.stderr, "wyrm: nothing to stop (%v)\n", kerr)
+		} else {
+			_, _ = fmt.Fprintf(a.stdout, "killed session %s\n", name)
+		}
+
+		name, _, _, err := session.Create(a.runner, cfg, a.stdout, a.stderr, session.WithHistory(hist))
+		if err != nil {
+			_, _ = fmt.Fprintf(a.stderr, "wyrm: warning: failed to restart session %s: %v\n", s.Name, err)
+			continue
+		}
+		_, _ = fmt.Fprintf(a.stdout, "created session %s\n", name)
+	}
+	return nil
+}
+
 // kill runs the on_project_exit hook and destroys the session. With a
 // positional name it targets that session instead of the current folder's,
 // mirroring `wyrm <name>` — killing by name was previously only possible from
@@ -206,16 +297,34 @@ func (a *app) kill(args []string) error {
 	fs := a.newFlagSet("kill")
 	configPath := fs.String("config", "", "path to config file (default: .wyrm.toml, then .tmuxconfig)")
 	dryRun := fs.Bool("n", false, "print the hook and kill that would run, without touching tmux")
+	allFlag := fs.Bool("all", false, "kill all active tmux sessions")
+	allShort := fs.Bool("a", false, "alias for -all")
+	yesFlag := fs.Bool("y", false, "skip confirmation prompt when killing all sessions")
+	yesLong := fs.Bool("yes", false, "alias for -y")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
-	if fs.NArg() > 1 {
-		return usageErrf("unexpected argument %q (kill takes at most one session name)", fs.Arg(1))
-	}
+
+	all := *allFlag || *allShort
+	yes := *yesFlag || *yesLong
 
 	settings, err := config.LoadSettings()
 	if err != nil {
 		return err
+	}
+
+	if all {
+		if *configPath != "" {
+			return usageErrf("-config and -all are mutually exclusive")
+		}
+		if fs.NArg() > 0 {
+			return usageErrf("session name and -all are mutually exclusive")
+		}
+		return a.killAll(settings, *dryRun, yes)
+	}
+
+	if fs.NArg() > 1 {
+		return usageErrf("unexpected argument %q (kill takes at most one session name)", fs.Arg(1))
 	}
 
 	// A named target resolves through the project list first, so its
@@ -243,6 +352,54 @@ func (a *app) kill(args []string) error {
 	}
 	if !*dryRun {
 		_, _ = fmt.Fprintf(a.stdout, "killed session %s\n", name)
+	}
+	return nil
+}
+
+func (a *app) killAll(settings *config.Settings, dryRun, yes bool) error {
+	active, err := sessions.List(a.runner)
+	if err != nil {
+		return err
+	}
+	if len(active) == 0 {
+		_, _ = fmt.Fprintln(a.stdout, "no active sessions to kill")
+		return nil
+	}
+
+	if !dryRun && !yes {
+		if !a.promptConfirm(fmt.Sprintf("Kill all %d active tmux session(s)? (y/N): ", len(active))) {
+			_, _ = fmt.Fprintln(a.stdout, "aborted")
+			return nil
+		}
+	}
+
+	var opts []session.Option
+	if dryRun {
+		opts = a.teardownDryRun()
+	}
+
+	for _, s := range active {
+		if project, found := config.FindProject(settings, s.Name); found {
+			if cfg, err := config.Load(project.Path); err == nil {
+				name, kerr := session.Kill(a.runner, cfg, a.stderr, opts...)
+				if kerr != nil {
+					_, _ = fmt.Fprintf(a.stderr, "wyrm: warning: failed to kill session %s: %v\n", s.Name, kerr)
+				} else if !dryRun {
+					_, _ = fmt.Fprintf(a.stdout, "killed session %s\n", name)
+				}
+				continue
+			}
+		}
+
+		if dryRun {
+			_, _ = fmt.Fprintf(a.stdout, "tmux kill-session -t %s\n", s.ID)
+		} else {
+			if out, err := a.runner.Run("kill-session", "-t", s.ID); err != nil {
+				_, _ = fmt.Fprintf(a.stderr, "wyrm: warning: failed to kill session %s: %v\n", s.Name, tmux.CmdErr(err, out))
+			} else {
+				_, _ = fmt.Fprintf(a.stdout, "killed session %s\n", s.Name)
+			}
+		}
 	}
 	return nil
 }

--- a/completions/_wyrm
+++ b/completions/_wyrm
@@ -48,8 +48,25 @@ _wyrm() {
             ;;
         args)
             case "$words[1]" in
-                up|restart|kill|edit|validate)
+                up|edit|validate)
                     _arguments '-config[config file path]:config file:->configs'
+                    ;;
+                restart)
+                    _arguments '-config[config file path]:config file:->configs' \
+                        '-all[restart all active tmux sessions]' \
+                        '-a[restart all active tmux sessions]' \
+                        '-yes[skip confirmation prompt]' \
+                        '-y[skip confirmation prompt]' \
+                        '-n[dry run]' \
+                        '-d[skip attaching]'
+                    ;;
+                kill)
+                    _arguments '-config[config file path]:config file:->configs' \
+                        '-all[kill all active tmux sessions]' \
+                        '-a[kill all active tmux sessions]' \
+                        '-yes[skip confirmation prompt]' \
+                        '-y[skip confirmation prompt]' \
+                        '-n[dry run]'
                     ;;
                 status)
                     _arguments '-format[output format]:format:(text json tmux waybar sketchybar)' \

--- a/completions/wyrm.bash
+++ b/completions/wyrm.bash
@@ -46,7 +46,9 @@ _wyrm_complete() {
     # Subcommand-specific flags.
     if [[ "$cur" == -* ]]; then
         case "$cmd" in
-            up|restart|kill|edit|validate) COMPREPLY=($(compgen -W "-config" -- "$cur")) ;;
+            up|edit|validate) COMPREPLY=($(compgen -W "-config -n" -- "$cur")) ;;
+            restart) COMPREPLY=($(compgen -W "-config -n -d -all -a -yes -y -var" -- "$cur")) ;;
+            kill) COMPREPLY=($(compgen -W "-config -n -all -a -yes -y" -- "$cur")) ;;
             status) COMPREPLY=($(compgen -W "-format -session -v" -- "$cur")) ;;
             list) COMPREPLY=($(compgen -W "-format" -- "$cur")) ;;
             selfupdate) COMPREPLY=($(compgen -W "-check -version" -- "$cur")) ;;

--- a/completions/wyrm.fish
+++ b/completions/wyrm.fish
@@ -42,6 +42,10 @@ complete -c wyrm -n "not __fish_seen_subcommand_from $subcommands" -a '(wyrm lis
 
 # Subcommand flags.
 complete -c wyrm -n '__fish_seen_subcommand_from up restart kill edit validate' -o config -d 'config file path' -r -a '(wyrm list-configs 2>/dev/null)'
+complete -c wyrm -n '__fish_seen_subcommand_from restart kill' -o all -d 'apply to all active sessions'
+complete -c wyrm -n '__fish_seen_subcommand_from restart kill' -o a -d 'apply to all active sessions'
+complete -c wyrm -n '__fish_seen_subcommand_from restart kill' -o yes -d 'skip confirmation prompt'
+complete -c wyrm -n '__fish_seen_subcommand_from restart kill' -o y -d 'skip confirmation prompt'
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o format -d 'output format' -x -a 'text json tmux waybar sketchybar'
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o session -d 'filter to session' -x
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o v -d 'verbose output'

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func runnerFromSettings(settings *config.Settings) tmux.Exec {
 // what lets each of them return a plain error instead of hand-rolling its own
 // "print wyrm: <err> and return 1" — see run's report.
 type app struct {
+	stdin          io.Reader
 	stdout, stderr io.Writer
 	runner         tmux.Runner
 	insideTmux     func() bool
@@ -61,6 +62,20 @@ type app struct {
 	// construction path below, where it defaults to http.DefaultClient;
 	// tests point it at an httptest server instead.
 	httpClient *http.Client
+}
+
+func (a *app) promptConfirm(msg string) bool {
+	_, _ = fmt.Fprint(a.stdout, msg)
+	in := a.stdin
+	if in == nil {
+		in = os.Stdin
+	}
+	var resp string
+	if _, err := fmt.Fscanln(in, &resp); err != nil {
+		return false
+	}
+	resp = strings.ToLower(strings.TrimSpace(resp))
+	return resp == "y" || resp == "yes"
 }
 
 // exitErr is a subcommand failure carrying an explicit exit status. A nil Err
@@ -120,8 +135,10 @@ func (a *app) report(err error) int {
 // silently-ignored or mutually-exclusive top-level flags can't arise.
 //
 // The verb implementations live in cmd_*.go, grouped by what they act on.
+var appStdin io.Reader
+
 func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux func() bool, attach func(string) error) int {
-	a := &app{stdout: stdout, stderr: stderr, runner: runner, insideTmux: insideTmux, attach: attach}
+	a := &app{stdin: appStdin, stdout: stdout, stderr: stderr, runner: runner, insideTmux: insideTmux, attach: attach}
 
 	if len(args) == 0 {
 		return a.report(a.up(nil))
@@ -224,8 +241,8 @@ Usage:
   wyrm [-config PATH]        build or attach the current folder's session (default)
   wyrm up [-config PATH]     same as bare wyrm, spelled explicitly (-n to dry-run, -d to skip attaching)
   wyrm <name>                attach to a running session, or start a known project, by name
-  wyrm restart [-config P]   stop the session and build it again (-n to dry-run, -d to skip attaching)
-  wyrm kill [name]           destroy the session (runs on_project_exit first; -n to dry-run)
+  wyrm restart [-config P]   stop the session and build it again (-all, -n, -d, -y)
+  wyrm kill [name]           destroy the session (runs on_project_exit first; -all, -n, -y)
   wyrm pick                  fuzzy-pick a running session and attach to it
   wyrm tui                   full-screen session manager (browse, preview, manage)
   wyrm save [-config PATH]   save the running session's layout as this folder's config

--- a/main_test.go
+++ b/main_test.go
@@ -82,6 +82,16 @@ func (f *fakeRunner) Run(args ...string) (string, error) {
 		f.seq++
 		return fmt.Sprintf("%%%d", f.seq), nil
 	case "list-sessions":
+		if len(args) >= 3 && args[1] == "-F" && args[2] == "#{session_id}|#{session_name}" {
+			var lines []string
+			for _, line := range strings.Split(f.listOutput, "\n") {
+				parts := strings.Split(line, "|")
+				if len(parts) >= 2 {
+					lines = append(lines, parts[0]+"|"+parts[len(parts)-1])
+				}
+			}
+			return strings.Join(lines, "\n"), nil
+		}
 		return f.listOutput, nil
 	case "display-message":
 		return f.displayMessageOutput, nil
@@ -1430,5 +1440,163 @@ name = "main"
 	}
 	if !strings.Contains(stdout.String(), "config valid") {
 		t.Errorf("expected config valid in stdout, got %q", stdout.String())
+	}
+}
+
+func TestRunKillAllFlagYes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		listOutput: strings.Join([]string{
+			"$1|1|0|1000|alpha",
+			"$2|1|0|1000|beta",
+		}, "\n"),
+	}
+	code := run([]string{"kill", "-all", "-y"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "killed session alpha") || !strings.Contains(out, "killed session beta") {
+		t.Errorf("stdout = %q, want killed messages for alpha and beta", out)
+	}
+}
+
+func TestRunKillAllConfirmed(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		listOutput: "$1|1|0|1000|alpha",
+	}
+	appStdin = strings.NewReader("y\n")
+	defer func() { appStdin = nil }()
+	code := run([]string{"kill", "--all"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "killed session alpha") {
+		t.Errorf("stdout = %q, want killed session alpha", stdout.String())
+	}
+}
+
+func TestRunKillAllAborted(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		listOutput: "$1|1|0|1000|alpha",
+	}
+	appStdin = strings.NewReader("n\n")
+	defer func() { appStdin = nil }()
+	code := run([]string{"kill", "--all"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "aborted") {
+		t.Errorf("stdout = %q, want aborted message", stdout.String())
+	}
+}
+
+func TestRunKillAllDryRun(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		listOutput: "$1|1|0|1000|alpha",
+	}
+	code := run([]string{"kill", "--all", "-n"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "tmux kill-session -t $1") {
+		t.Errorf("stdout = %q, want tmux kill-session command", stdout.String())
+	}
+}
+
+func TestRunKillAllNoSessions(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{}
+	code := run([]string{"kill", "--all"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no active sessions to kill") {
+		t.Errorf("stdout = %q, want no active sessions message", stdout.String())
+	}
+}
+
+func TestRunKillAllIncompatibleFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{}
+	code := run([]string{"kill", "--all", "-config", "foo.toml"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+
+	stderr.Reset()
+	code = run([]string{"kill", "--all", "somesession"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+}
+
+func TestRunRestartAll(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	settingsDir := filepath.Join(home, ".config", "wyrm")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sharedDir := filepath.Join(settingsDir, "settings")
+	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgContent := "[session]\nname = 'alpha'\n[[windows]]\nname = 'w'\n"
+	if err := os.WriteFile(filepath.Join(sharedDir, "alpha.wyrm.toml"), []byte(cfgContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		listOutput: "$1|1|0|1000|alpha",
+	}
+	code := run([]string{"restart", "--all", "-y"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "killed session alpha") || !strings.Contains(out, "created session alpha") {
+		t.Errorf("stdout = %q, want killed and created messages for alpha", out)
+	}
+}
+
+func TestRunRestartAllDryRun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	settingsDir := filepath.Join(home, ".config", "wyrm")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sharedDir := filepath.Join(settingsDir, "settings")
+	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgContent := "[session]\nname = 'alpha'\n[[windows]]\nname = 'w'\n"
+	if err := os.WriteFile(filepath.Join(sharedDir, "alpha.wyrm.toml"), []byte(cfgContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	r := &fakeRunner{
+		listOutput: "$1|1|0|1000|alpha",
+	}
+	code := run([]string{"restart", "--all", "-n"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Restarting session alpha") {
+		t.Errorf("stdout = %q, want Restarting session alpha header", stdout.String())
 	}
 }

--- a/man/wyrm.1
+++ b/man/wyrm.1
@@ -42,17 +42,21 @@ if one exists; otherwise start the known project named
 .I NAME
 (local or shared config).
 .TP
-.BI "wyrm restart [\-config " PATH "] [\-n] [\-d]"
+.BI "wyrm restart [\-config " PATH "] [\-n] [\-d] [\-all] [\-y]"
 Stop the session (running
 .B on_project_exit
-first) and build it again from the current config.
+first) and build it again from the current config. With
+.BR \-all ,
+restarts all active tmux sessions.
 .TP
-.BI "wyrm kill [" NAME "] [\-config " PATH "] [\-n]"
+.BI "wyrm kill [" NAME "] [\-config " PATH "] [\-n] [\-all] [\-y]"
 Destroy the session, running
 .B on_project_exit
 first. With no name, targets the current folder's session; with
 .IR NAME ,
-targets that session (or known project) instead.
+targets that session (or known project) instead. With
+.BR \-all ,
+destroys all active tmux sessions.
 .B \-config
 and a session name are mutually exclusive.
 .TP


### PR DESCRIPTION
## Summary
Resolves #39.

Adds bulk operations to `wyrm kill` and `wyrm restart`:
- Added `--all` (`-a`) and `--yes` (`-y`) flags
- Lists and processes all active tmux sessions
- Interactive confirmation prompt (skipped when `-y` is supplied or in dry-run mode)
- Executes project-specific `on_project_exit` lifecycle hooks for known configs
- Supports `-n` / `--dry-run` to preview commands without modifying tmux state
- Updated man page `wyrm.1` and shell completions (`bash`, `fish`, `zsh`)

## Testing
- Unit tests in `main_test.go` (`TestRunKillAllFlagYes`, `TestRunKillAllConfirmed`, `TestRunKillAllAborted`, `TestRunKillAllDryRun`, `TestRunKillAllNoSessions`, `TestRunKillAllIncompatibleFlags`, `TestRunRestartAll`, `TestRunRestartAllDryRun`)
- `make lint`, `make test`, and `make cover` passed (80.8% statement coverage)