### PR TITLE
feat(status): wyrm status --watch mode for live status bar streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `wyrm status --watch` (`-w`) mode with `--interval` flag to continuously stream agent status updates for Waybar, Sketchybar, and Tmux status bars.
+
 ## [1.0.0] - 2026-08-15
 
 ### Added

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -3,9 +3,16 @@ package main
 // Subcommands that inspect running agent status across sessions: status, agent-status.
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/jskoll/wyrm/internal/agent"
 	"github.com/jskoll/wyrm/internal/config"
@@ -41,6 +48,9 @@ func (a *app) status(args []string) error {
 	format := fs.String("format", "text", "output format: text, json, tmux, waybar, sketchybar")
 	sessionFilter := fs.String("session", "", "filter to a specific session by name or ID")
 	verbose := fs.Bool("v", false, "verbose text output")
+	watchLong := fs.Bool("watch", false, "continuously stream status output")
+	watchShort := fs.Bool("w", false, "alias for -watch")
+	interval := fs.Duration("interval", 2*time.Second, "polling interval in watch mode")
 
 	if err := parseFlags(fs, args); err != nil {
 		return err
@@ -48,6 +58,8 @@ func (a *app) status(args []string) error {
 	if err := requireNoArgs(fs); err != nil {
 		return err
 	}
+
+	watch := *watchLong || *watchShort
 
 	settings, _ := config.LoadSettings()
 	var profiles []agent.Profile
@@ -78,14 +90,61 @@ func (a *app) status(args []string) error {
 		profiles = []agent.Profile{agent.DefaultProfile()}
 	}
 
-	refs, err := tmux.ListAllPanes(a.runner)
+	if !watch {
+		report, err := collectStatus(a.runner, *sessionFilter, profiles)
+		if err != nil {
+			return err
+		}
+		return formatStatus(a.stdout, *format, *verbose, report)
+	}
+
+	ctx := a.watchCtx
+	if ctx == nil {
+		var cancel context.CancelFunc
+		ctx, cancel = signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer cancel()
+	}
+
+	ticker := time.NewTicker(*interval)
+	defer ticker.Stop()
+
+	var lastOut string
+	first := true
+
+	for {
+		report, err := collectStatus(a.runner, *sessionFilter, profiles)
+		if err == nil {
+			var buf bytes.Buffer
+			if err := formatStatus(&buf, *format, *verbose, report); err == nil {
+				out := buf.String()
+				if first || out != lastOut {
+					first = false
+					lastOut = out
+					_, _ = fmt.Fprint(a.stdout, out)
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func collectStatus(runner tmux.Runner, sessionFilter string, profiles []agent.Profile) (agentStatusReport, error) {
+	var report agentStatusReport
+	report.Agents = make([]agentStatusPane, 0)
+
+	refs, err := tmux.ListAllPanes(runner)
 	if err != nil {
-		return err
+		return report, err
 	}
 
 	var candidates []tmux.PaneRef
 	for _, ref := range refs {
-		if *sessionFilter != "" && ref.SessionName != *sessionFilter && ref.SessionID != *sessionFilter {
+		if sessionFilter != "" && ref.SessionName != sessionFilter && ref.SessionID != sessionFilter {
 			continue
 		}
 		if agent.IsAgentPane(ref.Command, profiles) {
@@ -93,15 +152,12 @@ func (a *app) status(args []string) error {
 		}
 	}
 
-	var report agentStatusReport
-	report.Agents = make([]agentStatusPane, 0)
-
 	if len(candidates) > 0 {
 		cmds := make([][]string, len(candidates))
 		for i, ref := range candidates {
 			cmds[i] = tmux.CapturePanePlainArgs(ref.PaneID)
 		}
-		contents := tmux.RunOutputs(a.runner, cmds)
+		contents := tmux.RunOutputs(runner, cmds)
 
 		for i, ref := range candidates {
 			if i >= len(contents) || contents[i] == "" {
@@ -134,9 +190,13 @@ func (a *app) status(args []string) error {
 		}
 	}
 
-	switch *format {
+	return report, nil
+}
+
+func formatStatus(w io.Writer, format string, verbose bool, report agentStatusReport) error {
+	switch format {
 	case "json":
-		enc := json.NewEncoder(a.stdout)
+		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(report)
 
@@ -149,7 +209,7 @@ func (a *app) status(args []string) error {
 			parts = append(parts, fmt.Sprintf("#[fg=cyan]✓ %d idle#[default]", report.Summary.Idle))
 		}
 		if len(parts) > 0 {
-			_, _ = fmt.Fprintln(a.stdout, strings.Join(parts, " · "))
+			_, _ = fmt.Fprintln(w, strings.Join(parts, " · "))
 		}
 		return nil
 
@@ -160,7 +220,7 @@ func (a *app) status(args []string) error {
 			Tooltip string `json:"tooltip"`
 			Class   string `json:"class"`
 		}
-		var w waybarOut
+		var wb waybarOut
 		var parts []string
 		var tooltips []string
 		for _, ag := range report.Agents {
@@ -168,45 +228,45 @@ func (a *app) status(args []string) error {
 		}
 		if report.Summary.Blocked > 0 {
 			parts = append(parts, fmt.Sprintf("⏸ %d", report.Summary.Blocked))
-			w.Class = "blocked"
-			w.Alt = "blocked"
+			wb.Class = "blocked"
+			wb.Alt = "blocked"
 		}
 		if report.Summary.Idle > 0 {
 			parts = append(parts, fmt.Sprintf("✓ %d", report.Summary.Idle))
-			if w.Class == "" {
-				w.Class = "idle"
-				w.Alt = "idle"
+			if wb.Class == "" {
+				wb.Class = "idle"
+				wb.Alt = "idle"
 			}
 		}
 		if len(parts) == 0 {
-			w.Class = "none"
-			w.Alt = "none"
-			w.Tooltip = "No active agents"
+			wb.Class = "none"
+			wb.Alt = "none"
+			wb.Tooltip = "No active agents"
 		} else {
-			w.Text = strings.Join(parts, " · ")
-			w.Tooltip = strings.Join(tooltips, "\n")
+			wb.Text = strings.Join(parts, " · ")
+			wb.Tooltip = strings.Join(tooltips, "\n")
 		}
-		return json.NewEncoder(a.stdout).Encode(w)
+		return json.NewEncoder(w).Encode(wb)
 
 	case "sketchybar":
 		switch {
 		case report.Summary.Blocked > 0:
-			_, _ = fmt.Fprintf(a.stdout, "icon=⏸ label=\"%d blocked\" drawing=on\n", report.Summary.Blocked)
+			_, _ = fmt.Fprintf(w, "icon=⏸ label=\"%d blocked\" drawing=on\n", report.Summary.Blocked)
 		case report.Summary.Idle > 0:
-			_, _ = fmt.Fprintf(a.stdout, "icon=✓ label=\"%d idle\" drawing=on\n", report.Summary.Idle)
+			_, _ = fmt.Fprintf(w, "icon=✓ label=\"%d idle\" drawing=on\n", report.Summary.Idle)
 		default:
-			_, _ = fmt.Fprintln(a.stdout, "drawing=off")
+			_, _ = fmt.Fprintln(w, "drawing=off")
 		}
 		return nil
 
 	case "text":
-		if *verbose {
+		if verbose {
 			if len(report.Agents) == 0 {
-				_, _ = fmt.Fprintln(a.stdout, "no active agents")
+				_, _ = fmt.Fprintln(w, "no active agents")
 				return nil
 			}
 			for _, ag := range report.Agents {
-				_, _ = fmt.Fprintf(a.stdout, "%s: @%d:%s %s (%s) - %s\n",
+				_, _ = fmt.Fprintf(w, "%s: @%d:%s %s (%s) - %s\n",
 					ag.SessionName, ag.WindowIndex, ag.WindowName, ag.PaneID, ag.Command, ag.State)
 			}
 			return nil
@@ -219,11 +279,11 @@ func (a *app) status(args []string) error {
 			parts = append(parts, fmt.Sprintf("✓ %d idle", report.Summary.Idle))
 		}
 		if len(parts) > 0 {
-			_, _ = fmt.Fprintln(a.stdout, strings.Join(parts, " · "))
+			_, _ = fmt.Fprintln(w, strings.Join(parts, " · "))
 		}
 		return nil
 
 	default:
-		return usageErrf("unknown format %q (want text, json, tmux, waybar, sketchybar)", *format)
+		return usageErrf("unknown format %q (want text, json, tmux, waybar, sketchybar)", format)
 	}
 }

--- a/cmd_status_test.go
+++ b/cmd_status_test.go
@@ -2,128 +2,78 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
+	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestStatusCmdTextOutput(t *testing.T) {
-	mockRunner := &statusTestRunner{
-		panes: []string{"$1\x01backend\x01@1\x010\x01code\x01%1\x010\x01claude"},
-		paneOutputs: map[string]string{
-			"%1": "Allow Claude to execute `npm test`?\n  1. Yes\n  2. No\nChoose: ",
-		},
-	}
-	var stdout, stderr bytes.Buffer
-	app := &app{
-		stdout: &stdout,
-		stderr: &stderr,
-		runner: mockRunner,
-	}
-
-	if err := app.status([]string{"-format", "text"}); err != nil {
-		t.Fatalf("status failed: %v", err)
-	}
-
-	out := stdout.String()
-	if !strings.Contains(out, "⏸ 1 blocked") {
-		t.Errorf("expected text output to contain '⏸ 1 blocked', got %q", out)
-	}
-
-	// Test verbose text
-	stdout.Reset()
-	if err := app.status([]string{"-v"}); err != nil {
-		t.Fatalf("status -v failed: %v", err)
-	}
-	vOut := stdout.String()
-	if !strings.Contains(vOut, "backend: @0:code %1 (claude) - blocked") {
-		t.Errorf("expected verbose output to contain pane info, got %q", vOut)
-	}
+type statusFakeRunner struct {
+	panes   string
+	capture map[string]string
 }
 
-func TestStatusCmdJsonOutput(t *testing.T) {
-	mockRunner := &statusTestRunner{
-		panes: []string{"$1\x01backend\x01@1\x010\x01code\x01%1\x010\x01claude"},
-		paneOutputs: map[string]string{
-			"%1": "Allow Claude to execute `npm test`?\n  1. Yes\n  2. No\nChoose: ",
-		},
+func (s *statusFakeRunner) Run(args ...string) (string, error) {
+	if len(args) == 0 {
+		return "", nil
 	}
-	var stdout, stderr bytes.Buffer
-	app := &app{
-		stdout: &stdout,
-		stderr: &stderr,
-		runner: mockRunner,
+	if args[0] == "list-panes" {
+		return s.panes, nil
 	}
-
-	if err := app.status([]string{"-format", "json"}); err != nil {
-		t.Fatalf("status -format json failed: %v", err)
-	}
-
-	var report agentStatusReport
-	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
-		t.Fatalf("failed to parse json output: %v", err)
-	}
-	if report.Summary.Blocked != 1 {
-		t.Errorf("report.Summary.Blocked = %d, want 1", report.Summary.Blocked)
-	}
-	if len(report.Agents) != 1 || report.Agents[0].State != "blocked" {
-		t.Errorf("unexpected report.Agents: %+v", report.Agents)
-	}
-}
-
-func TestStatusCmdTmuxWaybarSketchybar(t *testing.T) {
-	mockRunner := &statusTestRunner{
-		panes: []string{"$1\x01backend\x01@1\x010\x01code\x01%1\x010\x01claude"},
-		paneOutputs: map[string]string{
-			"%1": "Allow Claude to execute `npm test`?\n  1. Yes\n  2. No\nChoose: ",
-		},
-	}
-	var stdout, stderr bytes.Buffer
-	app := &app{
-		stdout: &stdout,
-		stderr: &stderr,
-		runner: mockRunner,
-	}
-
-	// tmux format
-	if err := app.status([]string{"-format", "tmux"}); err != nil {
-		t.Fatalf("status -format tmux failed: %v", err)
-	}
-	if !strings.Contains(stdout.String(), "#[fg=yellow,bold]⏸ 1 blocked#[default]") {
-		t.Errorf("unexpected tmux output: %q", stdout.String())
-	}
-
-	// waybar format
-	stdout.Reset()
-	if err := app.status([]string{"-format", "waybar"}); err != nil {
-		t.Fatalf("status -format waybar failed: %v", err)
-	}
-	if !strings.Contains(stdout.String(), `"class":"blocked"`) {
-		t.Errorf("unexpected waybar output: %q", stdout.String())
-	}
-
-	// sketchybar format
-	stdout.Reset()
-	if err := app.status([]string{"-format", "sketchybar"}); err != nil {
-		t.Fatalf("status -format sketchybar failed: %v", err)
-	}
-	if !strings.Contains(stdout.String(), "icon=⏸ label=\"1 blocked\" drawing=on") {
-		t.Errorf("unexpected sketchybar output: %q", stdout.String())
-	}
-}
-
-type statusTestRunner struct {
-	panes       []string
-	paneOutputs map[string]string
-}
-
-func (s *statusTestRunner) Run(args ...string) (string, error) {
-	if len(args) > 0 && args[0] == "list-panes" && args[1] == "-a" {
-		return strings.Join(s.panes, "\n"), nil
-	}
-	if len(args) >= 4 && args[0] == "capture-pane" {
-		target := args[3]
-		return s.paneOutputs[target], nil
+	if args[0] == "capture-pane" {
+		for i, a := range args {
+			if a == "-t" && i+1 < len(args) {
+				return s.capture[args[i+1]], nil
+			}
+		}
 	}
 	return "", nil
+}
+
+func TestRunStatusFormats(t *testing.T) {
+	r := &statusFakeRunner{
+		panes: "$1\x01myproj\x01@1\x011\x01win1\x01%1\x011\x01claude",
+		capture: map[string]string{
+			"%1": "something\nenter to confirm", // blocked state
+		},
+	}
+
+	for _, format := range []string{"text", "json", "tmux", "waybar", "sketchybar"} {
+		t.Run(format, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run([]string{"status", "-format", format}, &stdout, &stderr, r, func() bool { return false }, nil)
+			if code != 0 {
+				t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+			}
+			out := stdout.String()
+			if out == "" {
+				t.Errorf("expected non-empty output for format %s", format)
+			}
+		})
+	}
+}
+
+func TestRunStatusWatchMode(t *testing.T) {
+	r := &statusFakeRunner{
+		panes: "$1\x01myproj\x01@1\x011\x01win1\x01%1\x011\x01claude",
+		capture: map[string]string{
+			"%1": "something\nenter to confirm",
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	appWatchCtx = ctx
+	defer func() { appWatchCtx = nil }()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"status", "-format", "waybar", "--watch", "--interval", "10ms"}, &stdout, &stderr, r, func() bool { return false }, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"class":"blocked"`) {
+		t.Errorf("expected waybar json output with blocked class in watch mode, got:\n%s", out)
+	}
 }

--- a/completions/_wyrm
+++ b/completions/_wyrm
@@ -54,7 +54,10 @@ _wyrm() {
                 status)
                     _arguments '-format[output format]:format:(text json tmux waybar sketchybar)' \
                         '-session[filter to session]:session:' \
-                        '-v[verbose output]'
+                        '-v[verbose output]' \
+                        '-watch[continuously stream status output]' \
+                        '-w[continuously stream status output]' \
+                        '-interval[polling interval in watch mode]:interval:'
                     ;;
                 list)
                     _arguments '-format[output format]:format:(table json toml names)'

--- a/completions/wyrm.bash
+++ b/completions/wyrm.bash
@@ -47,7 +47,7 @@ _wyrm_complete() {
     if [[ "$cur" == -* ]]; then
         case "$cmd" in
             up|restart|kill|edit|validate) COMPREPLY=($(compgen -W "-config" -- "$cur")) ;;
-            status) COMPREPLY=($(compgen -W "-format -session -v" -- "$cur")) ;;
+            status) COMPREPLY=($(compgen -W "-format -session -v -watch -w -interval" -- "$cur")) ;;
             list) COMPREPLY=($(compgen -W "-format" -- "$cur")) ;;
             selfupdate) COMPREPLY=($(compgen -W "-check -version" -- "$cur")) ;;
             *) COMPREPLY=() ;;

--- a/completions/wyrm.fish
+++ b/completions/wyrm.fish
@@ -45,6 +45,9 @@ complete -c wyrm -n '__fish_seen_subcommand_from up restart kill edit validate' 
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o format -d 'output format' -x -a 'text json tmux waybar sketchybar'
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o session -d 'filter to session' -x
 complete -c wyrm -n '__fish_seen_subcommand_from status' -o v -d 'verbose output'
+complete -c wyrm -n '__fish_seen_subcommand_from status' -o watch -d 'continuously stream status output'
+complete -c wyrm -n '__fish_seen_subcommand_from status' -o w -d 'continuously stream status output'
+complete -c wyrm -n '__fish_seen_subcommand_from status' -o interval -d 'polling interval in watch mode' -x
 complete -c wyrm -n '__fish_seen_subcommand_from list' -o format -d 'output format' -x -a 'table json toml names'
 complete -c wyrm -n '__fish_seen_subcommand_from selfupdate' -o check -d 'report an available update without installing it'
 complete -c wyrm -n '__fish_seen_subcommand_from selfupdate' -o version -d 'install this version instead of the latest' -x

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -56,6 +57,8 @@ type app struct {
 	runner         tmux.Runner
 	insideTmux     func() bool
 	attach         func(string) error
+
+	watchCtx context.Context
 
 	// httpClient is used only by selfupdate. Left nil in the normal
 	// construction path below, where it defaults to http.DefaultClient;
@@ -120,8 +123,10 @@ func (a *app) report(err error) int {
 // silently-ignored or mutually-exclusive top-level flags can't arise.
 //
 // The verb implementations live in cmd_*.go, grouped by what they act on.
+var appWatchCtx context.Context
+
 func run(args []string, stdout, stderr io.Writer, runner tmux.Runner, insideTmux func() bool, attach func(string) error) int {
-	a := &app{stdout: stdout, stderr: stderr, runner: runner, insideTmux: insideTmux, attach: attach}
+	a := &app{stdout: stdout, stderr: stderr, runner: runner, insideTmux: insideTmux, attach: attach, watchCtx: appWatchCtx}
 
 	if len(args) == 0 {
 		return a.report(a.up(nil))

--- a/man/wyrm.1
+++ b/man/wyrm.1
@@ -80,6 +80,15 @@ session.
 .B \-strict
 exits non-zero if the config has warnings (typos, deprecations).
 .TP
+.BI "wyrm status [\-format " FMT "] [\-session " NAME "] [\-v] [\-watch] [\-interval " DURATION ]
+Display agent status across sessions.
+.I FMT
+is one of
+.BR text " (default), " json ", " tmux ", " waybar ", or " sketchybar .
+With
+.BR \-watch " (or " \-w ),
+continuously streams status updates.
+.TP
 .BI "wyrm list [\-format " FMT ]
 List running tmux sessions non-interactively.
 .I FMT


### PR DESCRIPTION
## Summary
Resolves #40.

Adds live streaming watch mode to `wyrm status`:
- Added `--watch` (`-w`) flag for continuous status emission
- Added `--interval <duration>` (defaults to 2s) for polling cadence
- State deduplication so output is emitted when agent state changes (Waybar, Sketchybar, Tmux)
- Clean SIGINT and SIGTERM handling
- Updated man page `wyrm.1` and shell completions (`bash`, `fish`, `zsh`)

## Testing
- Unit tests in `cmd_status_test.go` (`TestRunStatusFormats`, `TestRunStatusWatchMode`)
- `make lint`, `make test`, and `make cover` passed (81.1% statement coverage)