### PR TITLE
feat(tui): all-sessions toggle and wildcard deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `a` toggle in the TUI's Sessions panel: lists known-but-stopped projects alongside the running sessions, with `Enter` starting a stopped one. Gives `wyrm pick`, which has no Projects panel, a way to start a session rather than only attach to one.
+
+### Fixed
+- A `[[wildcard]]` match no longer duplicates a project that has its own config: a pattern such as `~/code/*` covers the directory you are standing in as well as its siblings, and the specific config now wins over the template.
+
 ## [1.1.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ config  = "~/.config/wyrm/settings/_client-template.wyrm.toml"
 
 `wyrm <name>` (the matched directory's basename) then builds a session
 rooted there using the template's windows, and the TUI's Projects panel
-marks matches with `~`. See
+marks matches with `~`. A directory with its own config keeps it — the
+specific config wins over the template, and the project is listed once. See
 [`docs/configuration.md`](docs/configuration.md) for the template format and
 the recursive `/**` pattern form.
 
@@ -353,12 +354,24 @@ selected pane.
 
 The four left panels form a hierarchy: **Projects** (every `.wyrm.toml` wyrm can
 discover — the local one plus the shared directory, marked `●` when a session by
-that name is running) → **Sessions** (running now) → **Windows** → **Panes**.
+that name is running) → **Sessions** (running now, or everything known with `a`) → **Windows** → **Panes**.
 Windows track the selected session and panes track the selected window. The main
 panel previews the selection: the live pane contents (via `capture-pane`) for the
 session panels, or the config file's contents on the Projects panel. Focus starts
 on **Sessions** — the usual reason to open the TUI is to get back to something
 already running.
+
+By default the **Sessions** panel lists what tmux is running. Pressing `a`
+widens it to every session you could be in: the running ones first, then each
+discovered project that isn't running, marked `stopped`. `Enter` on a stopped
+row builds its session (exactly like `Enter` on **Projects**), so `wyrm pick` —
+which shows no Projects panel — can start a session too, not only reach one.
+
+A project only appears there if wyrm can discover it: a `.wyrm.toml` in the
+current directory or the shared config directory, a `[[wildcard]]` pattern
+match, or (opt-in) a zoxide-known directory. If the panel shows only the
+project you are standing in, that is what to configure — see
+[`configuration.md`](docs/configuration.md).
 
 | Key | Action |
 |---|---|
@@ -367,7 +380,7 @@ already running.
 | `PgUp` / `PgDn`, `g` / `G` | move a screenful / jump to the first or last entry |
 | `/` | filter the focused panel (`Esc` clears it) |
 | `f` | find a pane across every session at once — see below |
-| `Enter` | attach — lands on the exact window/pane under the cursor (or, on Projects, starts/attaches the config's session) |
+| `Enter` | attach — lands on the exact window/pane under the cursor (or, on Projects and on a stopped **Sessions** row, starts/attaches the config's session) |
 | `x` | kill the focused session / window / pane (or, on Projects, stop the session running `on_project_exit`) — with a confirm |
 | `r` | rename the focused session or window |
 | `n` | new window in the current session |
@@ -378,6 +391,7 @@ already running.
 | `L` | cycle the focused window through tmux's standard layouts |
 | `z` | toggle zoom on the focused pane |
 | `e` | edit the selected project's config in `$EDITOR` |
+| `a` | on **Sessions**, also list known-but-stopped projects — `Enter` starts one |
 | `R` | reload the project and session lists |
 | `M` | open the context menu for the current selection |
 | `m` | toggle mouse capture |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,11 @@ config  = "~/.config/wyrm/settings/_dev-template.wyrm.toml"
 | `pattern` | string | A glob (`*`, `?`, `[...]`); `~` and `$VAR` are expanded. A trailing `/**` matches every directory nested at any depth under the base, instead of one level |
 | `config` | string | Path to the template config applied to every matching directory |
 
+A directory that has its own config is never listed twice: a pattern like
+`~/code/*` matches the directory you are standing in as well as its siblings,
+and that directory's own `.wyrm.toml` (or shared config) wins over the
+template.
+
 The template is an ordinary `.wyrm.toml`. Its `session.name` is normally left
 unset, since each matched directory's basename supplies it. Its
 `session.root` is always overridden with the matched directory regardless of

--- a/docs/index.md
+++ b/docs/index.md
@@ -244,19 +244,31 @@ selected pane.
 
 The four left panels form a hierarchy: **Projects** (every `.wyrm.toml` wyrm can
 discover — the local one plus the shared directory, marked `●` when a session by
-that name is running) → **Sessions** (running now) → **Windows** → **Panes**.
+that name is running) → **Sessions** (running now, or everything known with `a`) → **Windows** → **Panes**.
 Windows track the selected session and panes track the selected window. The main
 panel previews the selection: the live pane contents (via `capture-pane`) for the
 session panels, or the config file's contents on the Projects panel. Focus starts
 on **Sessions** — the usual reason to open the TUI is to get back to something
 already running.
 
+By default the **Sessions** panel lists what tmux is running. Pressing `a`
+widens it to every session you could be in: the running ones first, then each
+discovered project that isn't running, marked `stopped`. `Enter` on a stopped
+row builds its session (exactly like `Enter` on **Projects**), so `wyrm pick` —
+which shows no Projects panel — can start a session too, not only reach one.
+
+A project only appears there if wyrm can discover it: a `.wyrm.toml` in the
+current directory or the shared config directory, a `[[wildcard]]` pattern
+match, or (opt-in) a zoxide-known directory. If the panel shows only the
+project you are standing in, that is what to configure — see
+[`configuration.md`](configuration.md).
+
 | Key | Action |
 |---|---|
 | `Tab` / `Shift-Tab`, `1`–`4` | move focus between panels |
 | `↑` / `↓`, `j` / `k` | move the selection in the focused panel |
 | `f` | find a pane across every session at once |
-| `Enter` | attach — lands on the exact window/pane under the cursor (or, on Projects, starts/attaches the config's session) |
+| `Enter` | attach — lands on the exact window/pane under the cursor (or, on Projects and on a stopped **Sessions** row, starts/attaches the config's session) |
 | `x` | kill the focused session / window / pane (or, on Projects, stop the session running `on_project_exit`) — with a confirm |
 | `r` | rename the focused session or window |
 | `n` | new window in the current session |
@@ -267,6 +279,7 @@ already running.
 | `L` | cycle the focused window through tmux's standard layouts |
 | `z` | toggle zoom on the focused pane |
 | `e` | edit the selected project's config in `$EDITOR` |
+| `a` | on **Sessions**, also list known-but-stopped projects — `Enter` starts one |
 | `R` | reload the project and session lists |
 | `?` | show the full keyboard-shortcut help overlay (scrollable) |
 | `q` / `Ctrl-C` | quit |

--- a/internal/config/projects.go
+++ b/internal/config/projects.go
@@ -113,7 +113,27 @@ func DiscoverProjects(settings *Settings) []Project {
 			}
 		}
 	}
-	projects = append(projects, DiscoverWildcardProjects(settings)...)
+	// A wildcard match whose name a real config already claims is dropped: a
+	// pattern like "~/Code/*" covers the directory you are standing in as
+	// well as its siblings, so the project with its own .wyrm.toml would
+	// otherwise be listed twice — once from its file and once from the
+	// template. The specific config wins, which is the same precedence
+	// appendZoxideProjects applies for the same reason.
+	//
+	// Names, not paths, because that is the only thing the two have in
+	// common: the file-based entry's Path is its own config and the
+	// wildcard's is the shared template.
+	byName := make(map[string]bool, len(projects))
+	for _, p := range projects {
+		byName[p.Name] = true
+	}
+	for _, w := range DiscoverWildcardProjects(settings) {
+		if byName[w.Name] {
+			continue
+		}
+		byName[w.Name] = true
+		projects = append(projects, w)
+	}
 	return projects
 }
 

--- a/internal/config/projects_test.go
+++ b/internal/config/projects_test.go
@@ -194,6 +194,56 @@ func TestDiscoverProjectsWildcardDedup(t *testing.T) {
 	}
 }
 
+// TestDiscoverProjectsWildcardYieldsToOwnConfig covers the other half of the
+// identity model: a pattern like "~/code/*" also matches the directory the
+// user is standing in, and that directory's own config must not be shadowed
+// by — or listed alongside — the template's synthesized entry.
+func TestDiscoverProjectsWildcardYieldsToOwnConfig(t *testing.T) {
+	base := t.TempDir()
+	template := filepath.Join(t.TempDir(), "tmpl.wyrm.toml")
+	if err := os.WriteFile(template, []byte("[[windows]]\nname = \"w\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	own := filepath.Join(base, "mine")
+	if err := os.MkdirAll(own, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(base, "other"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "[session]\nname = \"mine\"\nroot = \".\"\n[[windows]]\nname = \"w\"\n"
+	if err := os.WriteFile(filepath.Join(own, DefaultFileName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(own)
+
+	settings := &Settings{Wildcard: []Wildcard{{Pattern: filepath.Join(base, "*"), Config: template}}}
+	got := DiscoverProjects(settings)
+
+	var mine []Project
+	for _, p := range got {
+		if p.Name == "mine" {
+			mine = append(mine, p)
+		}
+	}
+	if len(mine) != 1 {
+		t.Fatalf("project %q appears %d times, want once: %+v", "mine", len(mine), got)
+	}
+	if mine[0].Wildcard {
+		t.Errorf("project mine = %+v, want the local config to win over the template", mine[0])
+	}
+	// The sibling the user has no config for still comes from the template.
+	var other bool
+	for _, p := range got {
+		if p.Name == "other" && p.Wildcard {
+			other = true
+		}
+	}
+	if !other {
+		t.Errorf("sibling directory dropped: %+v", got)
+	}
+}
+
 // TestFindProjectAliasResolvesAfterExactName covers both halves of the
 // documented rule: an alias resolves a project, and an exact project name
 // always wins over an alias collision.

--- a/internal/tui/menu.go
+++ b/internal/tui/menu.go
@@ -65,8 +65,17 @@ func projectMenu(m Model) []menuEntry {
 }
 
 func sessionMenu(m Model) []menuEntry {
-	if _, ok := m.currentSession(); !ok {
+	e, ok := m.currentSessionEntry()
+	if !ok {
 		return nil
+	}
+	// A stopped row can only be started — everything below targets a session
+	// ID it doesn't have.
+	if !e.Running {
+		if !e.HasProject {
+			return nil
+		}
+		return []menuEntry{{menuStart, "Start session", "↵"}}
 	}
 	return []menuEntry{
 		{menuAttach, "Attach", "↵"},
@@ -176,7 +185,10 @@ func (m Model) runMenuEntry() (tea.Model, tea.Cmd) {
 	case menuAttach:
 		return m.attachToSelection()
 	case menuStart:
-		return m.startProject()
+		// Not startProject directly: the menu is always opened on the focused
+		// panel, and "start" means the project on Projects and the stopped row
+		// on Sessions. activateSelection is the one place that knows which.
+		return m.activateSelection()
 	case menuEdit:
 		return m.editProject()
 	case menuRename:

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -120,10 +120,22 @@ func (m Model) isDoubleClick(_ tea.MouseMsg, h hit) bool {
 	return m.now().Sub(m.lastClick.at) <= doubleClickWindow
 }
 
-// activateSelection is the click equivalent of Enter.
+// activateSelection is what Enter and a double click both do: start the thing
+// under the cursor if it isn't running, otherwise attach to it. Keys and mouse
+// share it so a double click can never mean something Enter doesn't.
 func (m Model) activateSelection() (tea.Model, tea.Cmd) {
-	if m.focus == panelProjects {
+	switch m.focus {
+	case panelProjects:
 		return m.startProject()
+	case panelSessions:
+		// With allSessions on the panel holds stopped rows too, and Enter on
+		// one means "start it" — the same thing Enter means on Projects.
+		if e, ok := m.currentSessionEntry(); ok && !e.Running {
+			if !e.HasProject {
+				return m, nil
+			}
+			return m, startProjectCmd(m.runner, m.settings, e.Project)
+		}
 	}
 	return m.attachToSelection()
 }

--- a/internal/tui/panels.go
+++ b/internal/tui/panels.go
@@ -80,7 +80,7 @@ var panelSpecs = [numPanels]panelSpec{
 		empty:  "no running sessions",
 		length: func(m Model) int { return len(m.visibleSessions()) },
 		rows:   sessionRows,
-		keys:   "↵: attach  x: kill  r: rename  n: new-win  " + navKeys,
+		keys:   "↵: attach/start  x: kill  r: rename  n: new-win  a: all  " + navKeys,
 		menu:   sessionMenu,
 		kill:   killSession,
 		child:  panelWindows,

--- a/internal/tui/sessionlist.go
+++ b/internal/tui/sessionlist.go
@@ -1,0 +1,88 @@
+package tui
+
+import "github.com/jskoll/wyrm/internal/sessions"
+
+// This file describes what the Sessions panel lists.
+//
+// By default it lists what tmux is running, and that is the whole answer. With
+// "all" toggled on ("a") it also lists every discoverable project that is
+// *not* running, so "reach the session I already have" and "start the one I
+// don't" are one list instead of two panels — which is the only way `wyrm
+// pick`, whose compact form has no Projects panel, can start anything at all.
+//
+// The two kinds of row are one type rather than two lists because every
+// consumer — the cursor, the filter, the renderer, the mouse hit test — indexes
+// rows positionally and must not care which kind it landed on.
+
+// sessionEntry is one row of the Sessions panel.
+type sessionEntry struct {
+	// Name is what the row is filtered and rendered by: the tmux session name
+	// for a running row, the session name the config would produce for a
+	// stopped one.
+	Name string
+
+	// Session is the live tmux session. Only meaningful when Running — a
+	// stopped row has no session ID, which is precisely why every
+	// session-targeting action guards on currentSession's ok.
+	Session sessions.Session
+	Running bool
+
+	// Project is the config this row can be started from, and HasProject
+	// whether there is one. A stopped row always has one (nothing else could
+	// have put it in the list); a running row has one only when a discovered
+	// project shares its name, which is what lets a session started outside
+	// wyrm still appear here with nothing to start.
+	Project    Project
+	HasProject bool
+}
+
+// sessionEntries builds the panel's rows: the running sessions in tmux's own
+// most-recently-active order, then — with allSessions on — the discovered
+// projects that aren't among them, in discovery order.
+//
+// Stopped rows come last rather than being interleaved by name: the running
+// ones are the ones with live state behind them (windows, panes, agent
+// markers), and sorting a stopped row between them would move the row a user
+// was about to press Enter on every time a session's activity changed.
+func (m Model) sessionEntries() []sessionEntry {
+	entries := make([]sessionEntry, 0, len(m.sessions))
+	if !m.allSessions {
+		for _, s := range m.sessions {
+			entries = append(entries, sessionEntry{Name: s.Name, Session: s, Running: true})
+		}
+		return entries
+	}
+
+	// First project wins a name collision, matching listProjects' own
+	// precedence (a real config over a zoxide directory of the same name).
+	byName := make(map[string]Project, len(m.projects))
+	for _, p := range m.projects {
+		if _, seen := byName[p.Name]; !seen {
+			byName[p.Name] = p
+		}
+	}
+
+	running := make(map[string]bool, len(m.sessions))
+	for _, s := range m.sessions {
+		running[s.Name] = true
+		e := sessionEntry{Name: s.Name, Session: s, Running: true}
+		if p, ok := byName[s.Name]; ok {
+			e.Project, e.HasProject = p, true
+		}
+		entries = append(entries, e)
+	}
+
+	// Running is decided against m.sessions rather than Project.Running:
+	// the two are separate snapshots (loadProjects and loadSessions land as
+	// separate messages), and trusting the annotation could list a project
+	// as stopped in the same frame its session is listed as running.
+	seen := make(map[string]bool, len(m.projects))
+	for _, p := range m.projects {
+		if running[p.Name] || seen[p.Name] {
+			continue
+		}
+		seen[p.Name] = true
+		entries = append(entries, sessionEntry{Name: p.Name, Project: p, HasProject: true})
+	}
+	return entries
+}

--- a/internal/tui/sessionlist_test.go
+++ b/internal/tui/sessionlist_test.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jskoll/wyrm/internal/sessions"
+)
+
+// model with two running sessions and three known projects, one of which
+// ("api") is the running session's own config.
+func allSessionsModel() Model {
+	m := New(nopRunner(), nil)
+	m.sessions = []sessions.Session{
+		{ID: "$1", Name: "api", Windows: 2, Attached: true},
+		{ID: "$2", Name: "adhoc", Windows: 1},
+	}
+	m.projects = []Project{
+		{Name: "api", Path: "/cfg/api.wyrm.toml", Running: true, SessionID: "$1"},
+		{Name: "dragon-cli", Path: "/cfg/dragon-cli.wyrm.toml"},
+		{Name: "notes", Root: "/home/notes", Zoxide: true},
+	}
+	return m
+}
+
+func entryNames(entries []sessionEntry) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	return names
+}
+
+func TestSessionEntriesDefaultsToRunningOnly(t *testing.T) {
+	m := allSessionsModel()
+	got := entryNames(m.sessionEntries())
+	want := []string{"api", "adhoc"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("sessionEntries() = %v, want %v", got, want)
+	}
+	for _, e := range m.sessionEntries() {
+		if !e.Running {
+			t.Errorf("entry %q Running = false, want true with allSessions off", e.Name)
+		}
+	}
+}
+
+func TestSessionEntriesAllAppendsStoppedProjects(t *testing.T) {
+	m := allSessionsModel()
+	m.allSessions = true
+
+	entries := m.sessionEntries()
+	got := entryNames(entries)
+	want := []string{"api", "adhoc", "dragon-cli", "notes"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("sessionEntries() = %v, want %v (running first, stopped after)", got, want)
+	}
+	// The running row that has a config keeps it; the one started outside
+	// wyrm has none.
+	if !entries[0].Running || !entries[0].HasProject {
+		t.Errorf("api entry = %+v, want running with a project", entries[0])
+	}
+	if !entries[1].Running || entries[1].HasProject {
+		t.Errorf("adhoc entry = %+v, want running with no project", entries[1])
+	}
+	for _, e := range entries[2:] {
+		if e.Running || !e.HasProject {
+			t.Errorf("entry %q = %+v, want stopped with a project", e.Name, e)
+		}
+	}
+}
+
+// A project annotated Running but absent from the session list must not be
+// listed twice or as stopped — the two lists arrive as separate messages, so
+// they disagree for a frame after every start and kill.
+func TestSessionEntriesTrustsSessionListOverProjectAnnotation(t *testing.T) {
+	m := allSessionsModel()
+	m.allSessions = true
+	m.projects = append(m.projects, Project{Name: "adhoc", Path: "/cfg/adhoc.wyrm.toml"})
+
+	got := entryNames(m.sessionEntries())
+	want := []string{"api", "adhoc", "dragon-cli", "notes"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("sessionEntries() = %v, want %v (no duplicate adhoc row)", got, want)
+	}
+}
+
+func TestCurrentSessionReportsFalseOnStoppedRow(t *testing.T) {
+	m := allSessionsModel()
+	m.allSessions = true
+	m.cur[panelSessions] = 2 // dragon-cli, stopped
+
+	if s, ok := m.currentSession(); ok {
+		t.Errorf("currentSession() on a stopped row = %+v, true; want false so session actions no-op", s)
+	}
+	e, ok := m.currentSessionEntry()
+	if !ok || e.Name != "dragon-cli" {
+		t.Fatalf("currentSessionEntry() = %+v, %v; want the dragon-cli row", e, ok)
+	}
+	// Everything that targets a session ID must decline rather than act.
+	if _, _, ok := killSession(m); ok {
+		t.Error("killSession on a stopped row = ok, want false")
+	}
+	if _, cmd := m.startRename(); cmd != nil {
+		t.Error("startRename on a stopped row returned a command, want none")
+	}
+	if _, cmd := m.startNewWindow(); cmd != nil {
+		t.Error("startNewWindow on a stopped row returned a command, want none")
+	}
+}
+
+func TestToggleAllSessionsKeyOnlyOnSessionsPanel(t *testing.T) {
+	m := allSessionsModel()
+	m.focus = panelProjects
+	m, _ = update(m, key("a"))
+	if m.allSessions {
+		t.Error(`"a" on the Projects panel toggled allSessions, want ignored`)
+	}
+
+	m.focus = panelSessions
+	m, _ = update(m, key("a"))
+	if !m.allSessions {
+		t.Fatal(`"a" on the Sessions panel did not turn allSessions on`)
+	}
+	if got := m.panelLen(panelSessions); got != 4 {
+		t.Errorf("Sessions panel length after toggle = %d, want 4", got)
+	}
+	m, _ = update(m, key("a"))
+	if m.allSessions {
+		t.Error(`second "a" did not turn allSessions back off`)
+	}
+}
+
+// The cursor can sit past the end of the shorter list when "all" is turned
+// off, so the toggle has to clamp it.
+func TestToggleAllSessionsOffClampsCursor(t *testing.T) {
+	m := allSessionsModel()
+	m.focus = panelSessions
+	m.allSessions = true
+	m.cur[panelSessions] = 3 // notes, only present while "all" is on
+
+	m, _ = update(m, key("a"))
+	if m.cur[panelSessions] >= len(m.sessionEntries()) {
+		t.Errorf("cursor = %d after toggling off, want < %d", m.cur[panelSessions], len(m.sessionEntries()))
+	}
+}
+
+func TestEnterStartsStoppedSessionRow(t *testing.T) {
+	var started []string
+	m := allSessionsModel()
+	m.runner = funcRunner{fn: func(args ...string) (string, error) {
+		started = append(started, strings.Join(args, " "))
+		return "", nil
+	}}
+	m.allSessions = true
+	m.focus = panelSessions
+	m.cur[panelSessions] = 2 // dragon-cli, stopped
+
+	_, cmd := update(m, key("enter"))
+	if cmd == nil {
+		t.Fatal("enter on a stopped row returned no command, want a start")
+	}
+	// The command loads the config from disk and fails there in a test, which
+	// is fine: what matters is that it is a start attempt, not an attach.
+	if msg, ok := run(cmd).(projectStartedMsg); !ok {
+		t.Errorf("enter on a stopped row produced %T, want projectStartedMsg", msg)
+	}
+}
+
+func TestEnterAttachesRunningSessionRow(t *testing.T) {
+	m := allSessionsModel()
+	m.allSessions = true
+	m.focus = panelSessions
+	m.cur[panelSessions] = 0 // api, running
+
+	next, _ := update(m, key("enter"))
+	if next.pendingAttach != "$1" {
+		t.Errorf("pendingAttach = %q, want $1 — a running row still attaches", next.pendingAttach)
+	}
+}
+
+func TestStoppedRowRendersAsStopped(t *testing.T) {
+	m := allSessionsModel()
+	m.allSessions = true
+
+	rows := sessionRows(m)
+	if len(rows) != 4 {
+		t.Fatalf("sessionRows = %d rows, want 4", len(rows))
+	}
+	text := func(r []span) string {
+		var b strings.Builder
+		for _, s := range r {
+			b.WriteString(s.text)
+		}
+		return b.String()
+	}
+	if got := text(rows[2]); !strings.Contains(got, "dragon-cli") || !strings.Contains(got, "stopped") {
+		t.Errorf("stopped row = %q, want the name and \"stopped\"", got)
+	}
+	if got := text(rows[0]); !strings.Contains(got, "(2w)") {
+		t.Errorf("running row = %q, want its window count", got)
+	}
+}
+
+func TestSessionMenuOffersStartOnStoppedRow(t *testing.T) {
+	m := allSessionsModel()
+	m.allSessions = true
+	m.cur[panelSessions] = 2
+
+	entries := sessionMenu(m)
+	if len(entries) != 1 || entries[0].op != menuStart {
+		t.Fatalf("sessionMenu on a stopped row = %+v, want a single Start entry", entries)
+	}
+
+	m.cur[panelSessions] = 0
+	entries = sessionMenu(m)
+	for _, e := range entries {
+		if e.op == menuStart {
+			t.Error("sessionMenu on a running row offers Start, want attach/rename/kill only")
+		}
+	}
+}
+
+// The filter indexes the same list the cursor does, so stopped rows have to be
+// filterable by name like any other.
+func TestFilterMatchesStoppedRows(t *testing.T) {
+	m := allSessionsModel()
+	m.allSessions = true
+	m.focus = panelSessions
+	m.filter = "dragon"
+
+	got := entryNames(m.visibleSessions())
+	if len(got) != 1 || got[0] != "dragon-cli" {
+		t.Errorf("visibleSessions() with filter %q = %v, want [dragon-cli]", m.filter, got)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -196,6 +196,14 @@ type Model struct {
 	filter    string
 	filtering bool
 
+	// allSessions widens the Sessions panel from "what tmux is running" to
+	// "everything I could be in", folding the not-running projects in as
+	// startable rows — see sessionEntries. Off by default: the panel's job in
+	// the four-panel cascade is the live tmux world, and Projects already
+	// stands beside it. It earns its keep in `wyrm pick`, which shows no
+	// Projects panel and so otherwise cannot start a stopped session at all.
+	allSessions bool
+
 	// agents holds the last agent-pane scan: which sessions, windows, and panes
 	// hold an AI agent that's waiting on the user. Empty until the first scan.
 	agents agentStatus
@@ -417,15 +425,16 @@ func (m Model) visibleProjects() []Project {
 	return out
 }
 
-func (m Model) visibleSessions() []sessions.Session {
+func (m Model) visibleSessions() []sessionEntry {
+	entries := m.sessionEntries()
 	f := m.filterFor(panelSessions)
 	if f == "" {
-		return m.sessions
+		return entries
 	}
-	out := make([]sessions.Session, 0, len(m.sessions))
-	for _, s := range m.sessions {
-		if _, ok := sessions.FuzzyMatch(f, s.Name); ok {
-			out = append(out, s)
+	out := make([]sessionEntry, 0, len(entries))
+	for _, e := range entries {
+		if _, ok := sessions.FuzzyMatch(f, e.Name); ok {
+			out = append(out, e)
 		}
 	}
 	return out
@@ -515,10 +524,25 @@ func (m Model) currentProject() (Project, bool) {
 	return list[m.cur[panelProjects]], true
 }
 
+// currentSession is the selected *running* session. A stopped row (only
+// reachable with allSessions on) reports false, which is deliberately the same
+// answer as an empty panel: every session-targeting action — attach, rename,
+// kill, new-window, the window cascade — already guards on it, so none of them
+// needs to learn that a row without a session ID now exists.
 func (m Model) currentSession() (sessions.Session, bool) {
+	e, ok := m.currentSessionEntry()
+	if !ok || !e.Running {
+		return sessions.Session{}, false
+	}
+	return e.Session, true
+}
+
+// currentSessionEntry is the selected row whether or not it is running — what
+// the renderer, the menu, and Enter need in order to tell the two apart.
+func (m Model) currentSessionEntry() (sessionEntry, bool) {
 	list := m.visibleSessions()
 	if m.cur[panelSessions] < 0 || m.cur[panelSessions] >= len(list) {
-		return sessions.Session{}, false
+		return sessionEntry{}, false
 	}
 	return list[m.cur[panelSessions]], true
 }
@@ -968,10 +992,16 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "enter":
-		if m.focus == panelProjects {
-			return m.startProject()
+		return m.activateSelection()
+	case "a":
+		// Scoped to the panel it changes, like "e" on Projects.
+		if m.focus != panelSessions {
+			return m, nil
 		}
-		return m.attachToSelection()
+		m.allSessions = !m.allSessions
+		// The row under the cursor moves when the list grows or shrinks, so
+		// the window cascade has to follow it — clampFocused is exactly that.
+		return m.clampFocused()
 	case "x":
 		return m.startKill()
 	case "r":

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -230,18 +230,26 @@ func projectRows(m Model) [][]span {
 }
 
 func sessionRows(m Model) [][]span {
-	sessions := m.visibleSessions()
-	rows := make([][]span, len(sessions))
-	for i, s := range sessions {
+	entries := m.visibleSessions()
+	rows := make([][]span, len(entries))
+	for i, e := range entries {
+		if !e.Running {
+			// A stopped row (allSessions only) has no windows to count and no
+			// agents to mark. "stopped" is spelled out rather than left as a
+			// missing dot: the difference between this row and the one above
+			// it is that Enter starts it, and that is worth a word.
+			rows[i] = []span{plain("  " + e.Name + " "), {hintStyle, "stopped"}}
+			continue
+		}
 		mark := plain(" ")
-		if s.Attached {
+		if e.Session.Attached {
 			mark = span{activeMark, "●"}
 		}
 		rows[i] = appendAgentMark([]span{
 			mark,
-			plain(" " + s.Name + " "),
-			{hintStyle, fmt.Sprintf("(%dw)", s.Windows)},
-		}, m.agents.session(s.ID))
+			plain(" " + e.Name + " "),
+			{hintStyle, fmt.Sprintf("(%dw)", e.Session.Windows)},
+		}, m.agents.session(e.Session.ID))
 	}
 	return rows
 }
@@ -480,7 +488,8 @@ var helpSections = []helpSection{
 		{"y", "copy project path to clipboard"},
 	}},
 	{"Sessions panel", [][2]string{
-		{"Enter", "attach (or switch-client inside tmux)"},
+		{"Enter", "attach, or start a stopped session"},
+		{"a", "also list stopped projects"},
 		{"x", "kill the session"},
 		{"r", "rename the session"},
 		{"n", "new window in this session"},


### PR DESCRIPTION
## What

Two related changes to project/session discovery in the TUI.

### `a` toggles the Sessions panel between running and all-known

The Sessions panel lists what tmux is running. Pressing `a` widens it to every
session you could be in: the running ones first, then each discovered project
that isn't running, rendered `dragon-cli  stopped`. `Enter` on a stopped row
builds its session — the same thing `Enter` means on **Projects** — as does a
double click and the context menu's single "Start session" entry.

This matters most in `wyrm pick`, whose compact two-panel form has no Projects
panel: previously it could only reach a session, never start one.

- `internal/tui/sessionlist.go` holds the new `sessionEntry` and
  `sessionEntries()`. Both kinds of row are one type rather than two lists
  because every consumer — cursor, filter, renderer, mouse hit test — indexes
  positionally and must not care which kind it landed on.
- `currentSession()` keeps its signature and reports `false` on a stopped row.
  That is deliberately the same answer as an empty panel, so attach, rename,
  kill, new-window and the window cascade all decline through guards they
  already had; none of them needs to learn that ID-less rows now exist.
  `currentSessionEntry()` is what the renderer, menu, and Enter use.
- Enter and double click now share `activateSelection`, so a double click can
  never mean something Enter doesn't.
- Whether a row is running is decided against the live session list, not
  `Project.Running`: the project and session lists arrive as separate messages
  and disagree for a frame after every start and kill.

### A wildcard no longer duplicates a project that has its own config

A pattern like `~/code/*` matches the directory you are standing in as well as
its siblings, so that project was listed twice — once from its own
`.wyrm.toml`, once from the template. `config.DiscoverProjects` now drops a
wildcard match whose name a file-based project already claims. Names, not
paths, because that is the only thing the two entries have in common. This is
the same precedence `appendZoxideProjects` already applied, for the same
reason.

## Testing

- 11 new tests in `internal/tui/sessionlist_test.go` covering the entry list,
  the toggle and its cursor clamp, Enter on both kinds of row, the renderer,
  the menu, and filtering stopped rows.
- 1 new test in `internal/config/projects_test.go` for the dedup, asserting
  the sibling without a config still comes from the template.
- Full suite green under `-race`; coverage 82.1% against the 75% floor.

Note: `make lint` fails on a stdlib typecheck under Go 1.27
(`math/rand/v2`) — it does so on a clean tree too and is unrelated to this
branch.
